### PR TITLE
Move context into a separate module

### DIFF
--- a/router/RelayRouter.res
+++ b/router/RelayRouter.res
@@ -267,19 +267,9 @@ module Router: {
   }
 }
 
-let context = React.createContext(Obj.magic())
+module Provider = RelayRouter__Context.Provider
 
-module Provider = {
-  let make = React.Context.provider(context)
-
-  let makeProps = (~value, ~children, ()) =>
-    {
-      "value": value,
-      "children": children,
-    }
-}
-
-let useRouterContext = (): routerContext => React.useContext(context)
+let useRouterContext = RelayRouter__Context.useRouterContext
 
 module RouteComponent = {
   @react.component

--- a/router/RelayRouter__Context.res
+++ b/router/RelayRouter__Context.res
@@ -1,0 +1,16 @@
+
+open RelayRouterTypes
+
+let context = React.createContext(Obj.magic())
+
+module Provider = {
+  let make = React.Context.provider(context)
+
+  let makeProps = (~value, ~children, ()) =>
+    {
+      "value": value,
+      "children": children,
+    }
+}
+
+let useRouterContext = (): routerContext => React.useContext(context)

--- a/router/RelayRouter__Context.resi
+++ b/router/RelayRouter__Context.resi
@@ -1,0 +1,7 @@
+module Provider : {
+  let make : React.component<{"value": RelayRouterTypes.routerContext, "children": React.element}>
+
+  let makeProps : (~value : RelayRouterTypes.routerContext, ~children: React.element, ()) => {"value": RelayRouterTypes.routerContext, "children": React.element}
+}
+
+let useRouterContext : unit => RelayRouterTypes.routerContext;


### PR DESCRIPTION
# Problem
When bundling rescript-relay-router it can happen that the value in
`let context` is different when called from different places. This causes
the following error
```
TypeError: Cannot read properties of undefined (reading 'history')
    at eval (/node_modules/rescript-relay-router/src/RelayRouterUtils.mjs?v=796fc44e:62:23)
    at useReducer (/node_modules/react-dom/cjs/react-dom-server.node.development.js:5005:57)
    at Object.useState (/node_modules/react-dom/cjs/react-dom-server.node.development.js:4943:10)
    at Proxy.useState (/node_modules/react/cjs/react.development.js:1620:21)
    at Module.useLocation (/node_modules/rescript-relay-router/src/RelayRouterUtils.mjs?v=796fc44e:61:37)
    at NotFoundPage (/src/pages/NotFoundPage.mjs:15:37)
    at renderWithHooks (/node_modules/react-dom/cjs/react-dom-server.node.development.js:5537:16)
    at renderIndeterminateComponent (/node_modules/react-dom/cjs/react-dom-server.node.development.js:5610:15)
    at renderElement (/node_modules/react-dom/cjs/react-dom-server.node.development.js:5825:7)
    at renderLazyComponent (/node_modules/react-dom/cjs/react-dom-server.node.development.js:5815:3)
```

# Solution 
Moving the context to a separate file ensures the code in the module
is only executed once and all other code uses the same value.

# Release notes
Fix issue where context between provider and link could be out of sync