### PR TITLE
Allow newer versions of Node.js

### DIFF
--- a/pkgPackage.json
+++ b/pkgPackage.json
@@ -2,7 +2,7 @@
   "name": "rescript-relay-router",
   "version": "0.0.15-editor-tooling.1",
   "engines": {
-    "node": "16"
+    "node": ">=16"
   },
   "main": "./RescriptRelayVitePlugin.mjs",
   "exports": {


### PR DESCRIPTION
Node 18 is out which contains `fetch` so we want to allow 
people to update.

We keep a reasonably modern version as minimum for the CLI
to rely on.

We choose no upper bound to prefer people being able to experiment
with newer Node versions rather than covering the small chance we use
an API that is removed at some point, breaking the package.