### PR TITLE
React memo dependency arrays should be exhaustive in Route.useIsRouteActive

### DIFF
--- a/cli/RescriptRelayRouterCli__Codegen.res
+++ b/cli/RescriptRelayRouterCli__Codegen.res
@@ -594,7 +594,7 @@ let isRouteActive = ({pathname}: RelayRouter.Bindings.History.location, ~exact: 
 @live
 let useIsRouteActive = (~exact=false, ()) => {
   let location = RelayRouter.Utils.useLocation()
-  React.useMemo1(() => isRouteActive(location, ~exact, ()), [location])
+  React.useMemo2(() => isRouteActive(location, ~exact, ()), (location, exact))
 }`
 }
 


### PR DESCRIPTION
When calling `React.memo` the memoised value should change when any of the used values change. In the generated route modules the `useIsRouteActive` function uses `React.memo` based on the `location` and `exact` key but the `exact` key is not part of the arguments array. This means that if a user writes the following code:

```js
let [exact, setExact] = useState(false);
let isActive = Route.useIsRouteActive(exact);
```

The `isActive` may not change in case the `exact` input is changed.