### PR TITLE
Define peer-dependency on React >=18.2.0 

### DIFF
--- a/pkgPackage.json
+++ b/pkgPackage.json
@@ -32,6 +32,7 @@
   },
   "peerDependencies": {
     "@rescript/react": "^0.10.3",
+    "react": ">=18.2.0",
     "rescript-relay": "^1.0.0-beta.11",
     "vite": "^2.8.0-beta.3"
   },


### PR DESCRIPTION
We expect applications using Rescript Relay Router to provide React for
us and we don't rely on the package ourselves which is common practice
for libraries building on top of React.

This also fixes an issue that Yarn (3) reports about a missing
peer-dependency in `react-router` which it otherwise expects us to
provide.

A peer-dependency on `react-dom` is not added because at the moment the
only reference to react-dom in R3 is to a `hydrateRoot` binding.
However, in other cases we expect the user application to take care of
bundling with Vite and hydrating the client with `hydrateRoot`. Thus we
expect this binding to be moved from the router to our development
application (or we should add a peerDependency on `react-dom`).

18.2.0 is chosen as minimum version based on
https://github.com/zth/rescript-relay-router/pull/42

To make future changes to `pkgPackage.json` easier and more readable
e16482e1650367870e97022f0fde491d9c2571c6 goes ahead and orders
all dependencies by name.