### PR TITLE
Move PreloadInsertingStream into router package

### DIFF
--- a/router/.gitignore
+++ b/router/.gitignore
@@ -1,0 +1,2 @@
+# Commit the PreloadInsertingStreamNode as it has no ReScript source file.
+!PreloadInsertingStreamNode.mjs

--- a/router/PreloadInsertingStreamNode.mjs
+++ b/router/PreloadInsertingStreamNode.mjs
@@ -4,7 +4,7 @@ function asRelayDataAppend(relayData) {
   return `window.__RELAY_DATA.push(${JSON.stringify(relayData)})`;
 }
 
-export default class PreloadInsertingStream extends Writable {
+export default class PreloadInsertingStreamNode extends Writable {
   constructor(writable) {
     super();
     this._queryData = [];

--- a/router/RelayRouter.res
+++ b/router/RelayRouter.res
@@ -4,6 +4,7 @@ module Link = RelayRouter__Link
 module Scroll = RelayRouter__Scroll
 module AssetPreloader = RelayRouter__AssetPreloader
 module NetworkUtils = RelayRouter__NetworkUtils
+module PreloadInsertingStreamNode = RelayRouter__PreloadInsertingStreamNode
 
 // TODO: This is now exposing RelayRouter internals because it's needed by the generated code.
 module Internal = RelayRouter__Internal

--- a/router/RelayRouter.resi
+++ b/router/RelayRouter.resi
@@ -4,6 +4,7 @@ module Link = RelayRouter__Link
 module Scroll = RelayRouter__Scroll
 module AssetPreloader = RelayRouter__AssetPreloader
 module NetworkUtils = RelayRouter__NetworkUtils
+module PreloadInsertingStreamNode = RelayRouter__PreloadInsertingStreamNode
 
 // TODO: This is now exposing RelayRouter internals because it's needed by the generated code.
 module Internal = RelayRouter__Internal

--- a/router/RelayRouter__PreloadInsertingStreamNode.res
+++ b/router/RelayRouter__PreloadInsertingStreamNode.res
@@ -1,0 +1,11 @@
+// PreloadInsertingStream is actually a Node.js `Writable` instance.
+// However, we don't want the router to depend on a NodeJS type package.
+// TODO: Ensure user-land doesn't have to write their own typecasting to use this stream.
+type t
+
+@new @module("./PreloadInsertingStreamNode.mjs") external make: 'a => t = "default"
+
+@send
+external onQuery: (t, ~id: string, ~response: option<'a>=?, ~final: option<bool>=?) => unit =
+  "onQuery"
+@send external onAssetPreload: (t, string) => unit = "onAssetPreload"


### PR DESCRIPTION
This allows applications to use the stream to easily inject assets
rather than having to provide their own.

This chooses to use an opaque type for the stream so that the router
does not need Node.js bindings, even though this makes consumption
slightly more difficult.

The name uses the `Node` suffix to indicate this is Node.js specific. We
can create a parallel `PreloadInsertingStreamTransform` for platforms
that use native web streams.

Fixes #66