### PR TITLE
Move non-optional parameters after optional parameters

### DIFF
--- a/cli/RescriptRelayRouterCli__Codegen.res
+++ b/cli/RescriptRelayRouterCli__Codegen.res
@@ -522,14 +522,14 @@ let getIsRouteActiveFn = (route: RescriptRelayRouterCli__Types.printableRoute) =
 let routePattern = "${route.path->RoutePath.toPattern}"
 
 @live
-let isRouteActive = ({pathname}: RelayRouter.Bindings.History.location, ~exact: bool=false, ()): bool => {
+let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.Bindings.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Belt.Option.isSome
 }
 
 @live
 let useIsRouteActive = (~exact=false, ()) => {
   let location = RelayRouter.Utils.useLocation()
-  React.useMemo2(() => isRouteActive(location, ~exact, ()), (location, exact))
+  React.useMemo2(() => location->isRouteActive(~exact), (location, exact))
 }`
 }
 

--- a/router/RelayRouter.res
+++ b/router/RelayRouter.res
@@ -126,7 +126,7 @@ module Router = {
     }
 
     @live
-    let preloadCode = (preloadUrl, ~priority=Default, ()) => {
+    let preloadCode = (~priority=Default, preloadUrl) => {
       preloadUrl->runOnEachRouteMatch((~match, ~queryParams, ~location as _) => {
         // We don't care about the unsub callback here
         let _ = Internal.runAtPriority(() => {
@@ -137,7 +137,7 @@ module Router = {
               ~queryParams,
               ~location,
             )->Js.Promise.then_(assetsToPreload => {
-              assetsToPreload->Belt.Array.forEach(asset => asset->preloadAsset(~priority))
+              assetsToPreload->Belt.Array.forEach(preloadAsset(~priority))
               Js.Promise.resolve()
             }, _)
         }, ~priority)
@@ -145,7 +145,7 @@ module Router = {
     }
 
     @live
-    let preload = (preloadUrl, ~priority=Default, ()) => {
+    let preload = (~priority=Default, preloadUrl) => {
       preloadUrl->runOnEachRouteMatch((~match, ~queryParams, ~location) => {
         // We don't care about the render function returned to us when
         // preparing, and we don't care about the run priority unsub
@@ -255,7 +255,7 @@ let useRegisterPreloadedAsset = asset => {
   let {preloadAsset} = useRouterContext()
   try {
     if RelaySSRUtils.ssr {
-      preloadAsset(asset, ~priority=Default)
+      asset->preloadAsset(~priority=Default)
     }
   } catch {
   | Js.Exn.Error(_) => ()

--- a/router/RelayRouter__AssetPreloader.res
+++ b/router/RelayRouter__AssetPreloader.res
@@ -56,7 +56,8 @@ let loadScriptTag = (~isModule=false, src) => {
   appendToHead(element)
 }
 
-let clientPreloadAsset = (asset, ~priority, ~preparedAssetsMap) => {
+type preparedAssetsMap = Js.Dict.t<bool>
+let makeClientAssetPreloader = (preparedAssetsMap, ~priority, asset) => {
   let assetIdentifier = switch asset {
   | RelayRouter__Types.Component({chunk}) => "component:" ++ chunk
   | Image({url}) => "image:" ++ url

--- a/router/RelayRouter__AssetPreloader.resi
+++ b/router/RelayRouter__AssetPreloader.resi
@@ -1,5 +1,2 @@
-let clientPreloadAsset: (
-  RelayRouter__Types.preloadAsset,
-  ~priority: RelayRouter__Types.preloadPriority,
-  ~preparedAssetsMap: Js.Dict.t<bool>,
-) => unit
+type preparedAssetsMap = Js.Dict.t<bool>
+let makeClientAssetPreloader: preparedAssetsMap => RelayRouter__Types.preloadAssetFn

--- a/router/RelayRouter__Link.res
+++ b/router/RelayRouter__Link.res
@@ -74,19 +74,13 @@ let make = (
 
   let doPreloadDataAndCode = React.useCallback3(
     overridePriority =>
-      router.preload(
-        to_,
-        ~priority=overridePriority->Belt.Option.getWithDefault(preloadPriority),
-        (),
-      ),
+      to_->router.preload(~priority=overridePriority->Belt.Option.getWithDefault(preloadPriority)),
     (to_, router.preload, preloadPriority),
   )
   let doPreloadCode = React.useCallback3(
     overridePriority =>
-      router.preloadCode(
-        to_,
+      to_->router.preloadCode(
         ~priority=overridePriority->Belt.Option.getWithDefault(preloadPriority),
-        (),
       ),
     (to_, router.preloadCode, preloadPriority),
   )

--- a/router/RelayRouter__Types.res
+++ b/router/RelayRouter__Types.res
@@ -12,7 +12,9 @@ type preloadAsset =
   | Component(preloadComponentAsset)
   | Image({url: string})
 
-type preloadAssetFn = (preloadAsset, ~priority: preloadPriority) => unit
+type preloadFn = (~priority: preloadPriority=?, string) => unit
+type preloadCodeFn = (~priority: preloadPriority=?, string) => unit
+type preloadAssetFn = (~priority: preloadPriority, preloadAsset) => unit
 type preparedRoute = {routeKey: string, render: renderRouteFn}
 
 type prepareIntent = Render | Preload
@@ -65,8 +67,8 @@ type onRouterEventFn = routerEvent => unit
 
 @live
 type routerContext = {
-  preload: (string, ~priority: preloadPriority=?, unit) => unit,
-  preloadCode: (string, ~priority: preloadPriority=?, unit) => unit,
+  preload: preloadFn,
+  preloadCode: preloadCodeFn,
   preloadAsset: preloadAssetFn,
   get: unit => currentRouterEntry,
   subscribe: subFn => unsubFn,

--- a/router/RelayRouter__Utils.res
+++ b/router/RelayRouter__Utils.res
@@ -6,8 +6,8 @@ let childRouteHasContent = childRoute => childRoute != React.null
 type routerHelpers = {
   push: string => unit,
   replace: string => unit,
-  preload: (string, ~priority: RelayRouter__Types.preloadPriority=?, unit) => unit,
-  preloadCode: (string, ~priority: RelayRouter__Types.preloadPriority=?, unit) => unit,
+  preload: RelayRouter__Types.preloadFn,
+  preloadCode: RelayRouter__Types.preloadCodeFn,
 }
 
 @live

--- a/router/RelayRouter__Utils.resi
+++ b/router/RelayRouter__Utils.resi
@@ -4,8 +4,8 @@ let childRouteHasContent: React.element => bool
 type routerHelpers = {
   push: string => unit,
   replace: string => unit,
-  preload: (string, ~priority: RelayRouter__Types.preloadPriority=?, unit) => unit,
-  preloadCode: (string, ~priority: RelayRouter__Types.preloadPriority=?, unit) => unit,
+  preload: RelayRouter__Types.preloadFn,
+  preloadCode: RelayRouter__Types.preloadCodeFn,
 }
 
 @live

--- a/src/EntryClient.res
+++ b/src/EntryClient.res
@@ -9,9 +9,7 @@ let boot = () => {
       ~routes,
       ~environment=RelayEnv.environment,
       ~routerEnvironment,
-      ~preloadAsset=RelayRouter.AssetPreloader.clientPreloadAsset(
-        ~preparedAssetsMap=RelayEnv.preparedAssetsMap,
-      ),
+      ~preloadAsset=RelayRouter.AssetPreloader.makeClientAssetPreloader(RelayEnv.preparedAssetsMap),
     )
 
     <Main environment=RelayEnv.environment routerContext />

--- a/src/EntryServer.res
+++ b/src/EntryServer.res
@@ -27,7 +27,7 @@ let default = (~request, ~response, ~clientScripts) => {
 
   // TODO: A default version of this should be provided by us/the router/the
   // framework, or in some way be made opaque to the dev in the default case.
-  let preloadAsset: RelayRouter.Types.preloadAssetFn = (asset, ~priority as _) =>
+  let preloadAsset: RelayRouter.Types.preloadAssetFn = (~priority as _, asset) =>
     switch asset {
     // TODO: If multiple lazy components are in the same chunk then this may load the same asset multiple times.
     | Component({chunk}) =>

--- a/src/RelayEnv.res
+++ b/src/RelayEnv.res
@@ -2,7 +2,7 @@ let preparedAssetsMap = Js.Dict.empty()
 
 let network = RescriptRelay.Network.makeObservableBased(
   ~observableFunction=NetworkUtils.makeFetchQuery(
-    ~preloadAsset=RelayRouter.AssetPreloader.clientPreloadAsset(~preparedAssetsMap),
+    ~preloadAsset=RelayRouter.AssetPreloader.makeClientAssetPreloader(preparedAssetsMap),
   ),
   (),
 )

--- a/src/test/routes/__generated__/Route__Root__Todos__Single_route.res
+++ b/src/test/routes/__generated__/Route__Root__Todos__Single_route.res
@@ -15,14 +15,14 @@ let makeLink = (~todoId: string, ~showMore: option<bool>=?, ()) => {
 let routePattern = "/todos/:todoId"
 
 @live
-let isRouteActive = ({pathname}: RelayRouter.Bindings.History.location, ~exact: bool=false, ()): bool => {
+let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.Bindings.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Belt.Option.isSome
 }
 
 @live
 let useIsRouteActive = (~exact=false, ()) => {
   let location = RelayRouter.Utils.useLocation()
-  React.useMemo2(() => isRouteActive(location, ~exact, ()), (location, exact))
+  React.useMemo2(() => location->isRouteActive(~exact), (location, exact))
 }
 
 @live

--- a/src/test/routes/__generated__/Route__Root__Todos_route.res
+++ b/src/test/routes/__generated__/Route__Root__Todos_route.res
@@ -9,14 +9,14 @@ let makeLink = () => {
 let routePattern = "/todos"
 
 @live
-let isRouteActive = ({pathname}: RelayRouter.Bindings.History.location, ~exact: bool=false, ()): bool => {
+let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.Bindings.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Belt.Option.isSome
 }
 
 @live
 let useIsRouteActive = (~exact=false, ()) => {
   let location = RelayRouter.Utils.useLocation()
-  React.useMemo2(() => isRouteActive(location, ~exact, ()), (location, exact))
+  React.useMemo2(() => location->isRouteActive(~exact), (location, exact))
 }
 @live
 type subRoute = [#Single]

--- a/src/test/routes/__generated__/Route__Root_route.res
+++ b/src/test/routes/__generated__/Route__Root_route.res
@@ -9,14 +9,14 @@ let makeLink = () => {
 let routePattern = "/"
 
 @live
-let isRouteActive = ({pathname}: RelayRouter.Bindings.History.location, ~exact: bool=false, ()): bool => {
+let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.Bindings.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Belt.Option.isSome
 }
 
 @live
 let useIsRouteActive = (~exact=false, ()) => {
   let location = RelayRouter.Utils.useLocation()
-  React.useMemo2(() => isRouteActive(location, ~exact, ()), (location, exact))
+  React.useMemo2(() => location->isRouteActive(~exact), (location, exact))
 }
 @live
 type subRoute = [#Todos]

--- a/src/utils/NetworkUtils.res
+++ b/src/utils/NetworkUtils.res
@@ -1,7 +1,7 @@
 // This is a simple example of how one could leverage `preloadAsset` to preload
 // things from the GraphQL response. This should live inside of the
 // (comprehensive) example application we're going to build eventually.
-let preloadFromResponse = (part: Js.Json.t, ~preloadAsset) => {
+let preloadFromResponse = (part: Js.Json.t, ~preloadAsset: RelayRouter__Types.preloadAssetFn) => {
   switch part->Js.Json.decodeObject {
   | None => ()
   | Some(obj) =>
@@ -21,7 +21,7 @@ let preloadFromResponse = (part: Js.Json.t, ~preloadAsset) => {
         )
         ->Belt.Option.getWithDefault([])
         ->Belt.Array.forEach(imgUrl => {
-          preloadAsset(RelayRouter.Types.Image({url: imgUrl}), ~priority=RelayRouter.Types.Default)
+          preloadAsset(~priority=RelayRouter.Types.Default, RelayRouter.Types.Image({url: imgUrl}))
         })
       }
     }


### PR DESCRIPTION
This makes it easier to pipe into functions or do partial application of
functions.

This also introduces types for the preload functions so that they're
consistent throughout the code-base.

We rename `makeClientAssetPreloader` to better indicate that it takes
only a single argument and returns a new function that you should give
to something else. With than in mind we also make it an unnamed
argument. Unfortunately ReScript format puts together the argument
declaration which makes it less obvious in code that it returns a
function, though its interface signature makes that clear now.

Closes #25