### PR TITLE
Allow development application to use newer versions of Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "main",
   "version": "0.0.0",
   "engines": {
-    "node": "16"
+    "node": ">=16"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Since my terminal constantly tells me that my default Node 18 version isn't good enough 🙃 

We did this for the router but forgot to do so for our dev application.