### PR TITLE
Change script insertion to `import` for immediate preloads

### DIFF
--- a/router/RelayRouter__AssetPreloader.res
+++ b/router/RelayRouter__AssetPreloader.res
@@ -14,7 +14,7 @@ external setRel: (Dom.element, [#modulepreload | #preload]) => unit = "rel"
 external setAs: (Dom.element, [#image]) => unit = "as"
 
 @val
-external loadScript : string => unit = "import"
+external loadScript: string => unit = "import"
 
 @live
 let preloadAssetViaLinkTag = asset => {


### PR DESCRIPTION
We've been informed by trustable sources that `import` is equal to a
dynamically inserted `<script type="module">` (and that `async` is
implied when dynamically inserting scripts).

To simplify our code, for the scripts we want to preload immediately
rather than whenever the browser has time we use an asymc import.