### PR TITLE
Introduce typesafety for our EntryServer

### DIFF
--- a/examples/express/src/EntryServer.res
+++ b/examples/express/src/EntryServer.res
@@ -6,7 +6,7 @@ external transformAsWritable: RelayRouter.PreloadInsertingStream.Node.t => NodeJ
   "%identity"
 
 @live
-let default = (~request, ~response, ~bootstrapModules) => {
+let handleRequest = (~request, ~response, ~bootstrapModules) => {
   // TODO: request should be transformed from Express to native Request and the url should be retrieved from there.
   let initialUrl = request->Express.Request.originalUrl
 

--- a/examples/express/src/bindings/Vite.res
+++ b/examples/express/src/bindings/Vite.res
@@ -12,17 +12,7 @@ let make = (~middlewareMode) => make({server: {middlewareMode: middlewareMode}})
 
 @get external middlewares: t => Express.middleware = "middlewares"
 
-@send external ssrLoadModule: (t, string) => 'a = "ssrLoadModule"
-
-type ssrEntryPoint = (
-  ~response: Express.Response.t,
-  ~head: string,
-  ~url: string,
-  ~bootstrapModules: array<string>,
-  ~isLoggedIn: bool,
-) => Promise.t<unit>
-let loadDevSsrEntryPoint: (t, string) => Promise.t<'a> = (vite, package) =>
-  vite->ssrLoadModule(package)
+@send external ssrLoadModule: (t, string) => Promise.t<'a> = "ssrLoadModule"
 
 @send external transformIndexHtml: (t, string, string) => Promise.t<string> = "transformIndexHtml"
 

--- a/examples/express/src/bindings/Vite.resi
+++ b/examples/express/src/bindings/Vite.resi
@@ -5,14 +5,7 @@ let make: (~middlewareMode: middlewareMode) => Promise.t<t>
 
 @get external middlewares: t => Express.middleware = "middlewares"
 
-type ssrEntryPoint = (
-  ~response: Express.Response.t,
-  ~head: string,
-  ~url: string,
-  ~bootstrapModules: array<string>,
-  ~isLoggedIn: bool,
-) => Promise.t<unit>
-let loadDevSsrEntryPoint: (t, string) => Promise.t<'a>
+@send external ssrLoadModule: (t, string) => Promise.t<'a> = "ssrLoadModule"
 
 @send external transformIndexHtml: (t, string, string) => Promise.t<string> = "transformIndexHtml"
 


### PR DESCRIPTION
Due to some clever features in the ReScript typesystem we can transfer
the type of the EntryServer module and indicate that our dynamically
imported server entrypoint is of that module type. This gives us
typesafety across the dynamic import!

Found this trick in https://forum.rescript-lang.org/t/modules-with-delimiters-in-the-filename/3538/4?u=kingdutch