### PR TITLE
Make link with preserved path

### DIFF
--- a/.changeset/breezy-waves-occur.md
+++ b/.changeset/breezy-waves-occur.md
@@ -1,0 +1,5 @@
+---
+"rescript-relay-router": patch
+---
+
+Add useMakeLinkWithPreservedPath helper to generated route cod"

--- a/examples/express/src/routes/__generated__/Route__Root__Todos__ByStatus_route.res
+++ b/examples/express/src/routes/__generated__/Route__Root__Todos__ByStatus_route.res
@@ -148,6 +148,20 @@ let makeLinkFromQueryParams = (~byStatus: [#completed | #notCompleted], queryPar
   makeLink(~byStatus, ~statuses=?queryParams.statuses, ())
 }
 
+@live
+let useMakeLinkWithPreservedPath = () => {
+  let location = RelayRouter.Utils.useLocation()
+  React.useMemo2(() => {
+    (makeNewQueryParams: queryParams => queryParams) => {
+      let newQueryParams = location.search->parseQueryParams->makeNewQueryParams
+      open RelayRouter.Bindings
+      let queryParams = location.search->QueryParams.parse
+      queryParams->applyQueryParams(~newParams=newQueryParams)
+      location.pathname ++ queryParams->QueryParams.toString
+    }
+  }, (location.search, location.search))
+}
+
 
 @live
 type pathParam_byStatus = [#completed | #notCompleted]

--- a/examples/express/src/routes/__generated__/Route__Root__Todos__Single_route.res
+++ b/examples/express/src/routes/__generated__/Route__Root__Todos__Single_route.res
@@ -170,6 +170,20 @@ let makeLinkFromQueryParams = (~todoId: string, queryParams: queryParams) => {
   makeLink(~todoId, ~statuses=?queryParams.statuses, ~showMore=?queryParams.showMore, ())
 }
 
+@live
+let useMakeLinkWithPreservedPath = () => {
+  let location = RelayRouter.Utils.useLocation()
+  React.useMemo2(() => {
+    (makeNewQueryParams: queryParams => queryParams) => {
+      let newQueryParams = location.search->parseQueryParams->makeNewQueryParams
+      open RelayRouter.Bindings
+      let queryParams = location.search->QueryParams.parse
+      queryParams->applyQueryParams(~newParams=newQueryParams)
+      location.pathname ++ queryParams->QueryParams.toString
+    }
+  }, (location.search, location.search))
+}
+
 
 @live
 let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.History.location): bool => {

--- a/examples/express/src/routes/__generated__/Route__Root__Todos_route.res
+++ b/examples/express/src/routes/__generated__/Route__Root__Todos_route.res
@@ -146,6 +146,20 @@ let makeLinkFromQueryParams = (queryParams: queryParams) => {
   makeLink(~statuses=?queryParams.statuses, ())
 }
 
+@live
+let useMakeLinkWithPreservedPath = () => {
+  let location = RelayRouter.Utils.useLocation()
+  React.useMemo2(() => {
+    (makeNewQueryParams: queryParams => queryParams) => {
+      let newQueryParams = location.search->parseQueryParams->makeNewQueryParams
+      open RelayRouter.Bindings
+      let queryParams = location.search->QueryParams.parse
+      queryParams->applyQueryParams(~newParams=newQueryParams)
+      location.pathname ++ queryParams->QueryParams.toString
+    }
+  }, (location.search, location.search))
+}
+
 
 @live
 let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.History.location): bool => {


### PR DESCRIPTION
Adds helper `useMakeLinkWithPreservedPath` for creating links preserving the current path. 

Useful for for example modals that are valid for a large portion of views, and where opening or closing the modal is just about changing a query param value, regardless of the underlying path.

Examples coming to the docs eventually (when they exist 😄 ).