### PR TITLE
fix loadFn not a function

### DIFF
--- a/.changeset/famous-fishes-raise.md
+++ b/.changeset/famous-fishes-raise.md
@@ -1,0 +1,5 @@
+---
+"rescript-relay-router": patch
+---
+
+Fix the type of the generated loadFn in loadRouteRenderer

--- a/examples/client-rendering/src/routes/__generated__/RouteDeclarations.res
+++ b/examples/client-rendering/src/routes/__generated__/RouteDeclarations.res
@@ -13,7 +13,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
   [
       {
     let routeName = "Root"
-    let loadRouteRenderer = () => Js.import(Root_route_renderer.renderer)->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
+    let loadRouteRenderer = () => (() => Js.import(Root_route_renderer.renderer))->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
     let makePrepareProps = (. 
     ~environment: RescriptRelay.Environment.t,
     ~pathParams: Js.Dict.t<string>,
@@ -82,7 +82,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
       ),
       children: [    {
         let routeName = "Root__Todos"
-        let loadRouteRenderer = () => Js.import(Root__Todos_route_renderer.renderer)->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
+        let loadRouteRenderer = () => (() => Js.import(Root__Todos_route_renderer.renderer))->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
         let makePrepareProps = (. 
         ~environment: RescriptRelay.Environment.t,
         ~pathParams: Js.Dict.t<string>,
@@ -150,7 +150,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
           ),
           children: [      {
               let routeName = "Root__Todos__ByStatus"
-              let loadRouteRenderer = () => Js.import(Root__Todos__ByStatus_route_renderer.renderer)->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
+              let loadRouteRenderer = () => (() => Js.import(Root__Todos__ByStatus_route_renderer.renderer))->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
               let makePrepareProps = (. 
               ~environment: RescriptRelay.Environment.t,
               ~pathParams: Js.Dict.t<string>,
@@ -220,7 +220,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
             },
             {
               let routeName = "Root__Todos__Single"
-              let loadRouteRenderer = () => Js.import(Root__Todos__Single_route_renderer.renderer)->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
+              let loadRouteRenderer = () => (() => Js.import(Root__Todos__Single_route_renderer.renderer))->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
               let makePrepareProps = (. 
               ~environment: RescriptRelay.Environment.t,
               ~pathParams: Js.Dict.t<string>,

--- a/examples/express/src/routes/__generated__/RouteDeclarations.res
+++ b/examples/express/src/routes/__generated__/RouteDeclarations.res
@@ -13,7 +13,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
   [
       {
     let routeName = "Root"
-    let loadRouteRenderer = () => Js.import(Root_route_renderer.renderer)->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
+    let loadRouteRenderer = () => (() => Js.import(Root_route_renderer.renderer))->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
     let makePrepareProps = (. 
     ~environment: RescriptRelay.Environment.t,
     ~pathParams: Js.Dict.t<string>,
@@ -82,7 +82,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
       ),
       children: [    {
         let routeName = "Root__Todos"
-        let loadRouteRenderer = () => Js.import(Root__Todos_route_renderer.renderer)->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
+        let loadRouteRenderer = () => (() => Js.import(Root__Todos_route_renderer.renderer))->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
         let makePrepareProps = (. 
         ~environment: RescriptRelay.Environment.t,
         ~pathParams: Js.Dict.t<string>,
@@ -150,7 +150,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
           ),
           children: [      {
               let routeName = "Root__Todos__ByStatus"
-              let loadRouteRenderer = () => Js.import(Root__Todos__ByStatus_route_renderer.renderer)->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
+              let loadRouteRenderer = () => (() => Js.import(Root__Todos__ByStatus_route_renderer.renderer))->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
               let makePrepareProps = (. 
               ~environment: RescriptRelay.Environment.t,
               ~pathParams: Js.Dict.t<string>,
@@ -220,7 +220,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
             },
             {
               let routeName = "Root__Todos__Single"
-              let loadRouteRenderer = () => Js.import(Root__Todos__Single_route_renderer.renderer)->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
+              let loadRouteRenderer = () => (() => Js.import(Root__Todos__Single_route_renderer.renderer))->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
               let makePrepareProps = (. 
               ~environment: RescriptRelay.Environment.t,
               ~pathParams: Js.Dict.t<string>,

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res
@@ -520,7 +520,7 @@ let rec getRouteDefinition = (route: printableRoute, ~indentation): string => {
 
   let str = `{
   let routeName = "${routeName}"
-  let loadRouteRenderer = () => Js.import(${routeName}_route_renderer.renderer)->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
+  let loadRouteRenderer = () => (() => Js.import(${routeName}_route_renderer.renderer))->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
   let makePrepareProps = ${route->getMakePrepareProps(~returnMode=ForInlinedRouteFn)}
 
   {


### PR DESCRIPTION
loadFn should be of type `unit => promise<RouteRenderer.t>`

I think we could simplify the types so we could get rid of Obj.magic altogether.