### PR TITLE
change manifest.json path for vite 5.0

### DIFF
--- a/packages/rescript-relay-router/vite-plugins/RescriptRelayVitePlugin.mjs
+++ b/packages/rescript-relay-router/vite-plugins/RescriptRelayVitePlugin.mjs
@@ -307,7 +307,7 @@ export let rescriptRelayVitePlugin = ({
       const manifestName =
         typeof config.build.manifest === "string"
           ? config.build.manifest
-          : "manifest.json";
+          : ".vite/manifest.json";
       const inPath = path.join(cwd, config.build.outDir, manifestName);
       const outPath = path.join(cwd, config.build.outDir, ROUTER_MANIFEST_NAME);
 


### PR DESCRIPTION
manifest.json default path got moved into a .vite folder cf vitejs/vite#14230