### PR TITLE
remove the unused `href` parameter from `RelayRouter.Utils.useIsRouteActive`

### DIFF
--- a/.changeset/slow-turtles-approve.md
+++ b/.changeset/slow-turtles-approve.md
@@ -1,0 +1,5 @@
+---
+"rescript-relay-router": major
+---
+
+remove the unused `href` parameter from `RelayRouter.Utils.useIsRouteActive`

--- a/packages/rescript-relay-router/README.md
+++ b/packages/rescript-relay-router/README.md
@@ -323,7 +323,7 @@ A few notes on preloading:
 
 If your only scrolling area is the document itself, you can enable scroll restoration via the router (if you don't prefer the browser's built in scroll restoration) by simply rendering `<RelayRouterScroll.ScrollRestoration />` inside of your app, close to the router provider.
 
-> Remember to turn off the built in browser scroll restoration if you do this: `` %%raw(`window.history.scrollRestoration = "manual"`) ``
+> Remember to turn off the built in browser scroll restoration if you do this: ``%%raw(`window.history.scrollRestoration = "manual"`)``
 
 If you have scrolling content areas that isn't scrolling on the main document itself, you'll need to tell the router about it so it can correctly help you with scroll restoration, and look at the intersection of the correct elements when detecting if links are in view yet. You tell the router about your scrolling areas this way:
 
@@ -548,7 +548,6 @@ module NavLink = {
   @react.component
   let make = (~href, ~routePattern, ~exact=false) => {
     let isRouteActive = RelayRouterUtils.useIsRouteActive(
-      ~href=linkHref,
       // Every route has a `routePattern` you can use
       ~routePattern=Routes.Organization.Members.Route.routePattern,
       // Whether to check whether _exactly_ this route is active. `false` means subroutes of the route will also say it's active.

--- a/packages/rescript-relay-router/src/RelayRouter__Utils.res
+++ b/packages/rescript-relay-router/src/RelayRouter__Utils.res
@@ -65,11 +65,11 @@ let isRouteActive = (~pathname, ~routePattern, ~exact=false) => {
   )->Belt.Option.isSome
 }
 
-let useIsRouteActive = (~href, ~routePattern, ~exact=false) => {
+let useIsRouteActive = (~routePattern, ~exact=false) => {
   let {pathname} = useLocation()
 
   React.useMemo(
     () => isRouteActive(~pathname, ~routePattern, ~exact),
-    (pathname, href, routePattern, exact),
+    (pathname, routePattern, exact),
   )
 }

--- a/packages/rescript-relay-router/src/RelayRouter__Utils.resi
+++ b/packages/rescript-relay-router/src/RelayRouter__Utils.resi
@@ -19,4 +19,4 @@ let useLocation: unit => RelayRouter__History.location
 let isRouteActive: (~pathname: string, ~routePattern: string, ~exact: bool=?) => bool
 
 @live
-let useIsRouteActive: (~href: string, ~routePattern: string, ~exact: bool=?) => bool
+let useIsRouteActive: (~routePattern: string, ~exact: bool=?) => bool


### PR DESCRIPTION
Technically this is a *breaking* change of the API, so I set the changeset as major, but I can modify it of course.