### PR TITLE
[codex] Make generated route keys collision-safe

### DIFF
--- a/.changeset/collision-safe-route-keys.md
+++ b/.changeset/collision-safe-route-keys.md
@@ -1,0 +1,5 @@
+---
+"rescript-relay-router": patch
+---
+
+Generate collision-safe prepared route keys by length-prefixing route names, path params, query params, and repeated query param values.

--- a/docs/router-optimization-opportunities.md
+++ b/docs/router-optimization-opportunities.md
@@ -12,7 +12,6 @@ The intent is that each section can be picked up as an independent work item. So
 | P0 | Centralize manifest-backed asset preloading | High for SSR, hydration, and route transitions | Medium | SSR/build integration |
 | P1 | Reuse unchanged prepared matches with explicit freshness policy | High for nested routes with parent queries | High | Relay/runtime |
 | P1 | Centralize location subscriptions | Medium to high in nav-heavy UIs | Medium | React runtime |
-| P1 | Make route keys collision-safe | Correctness fix with cache perf implications | Low | Codegen |
 | P2 | Split route declaration payload from route prepare modules | High in very large apps | High | Codegen/build |
 | P2 | Verify and improve renderer chunk boundaries | Medium bundle-size opportunity | Medium | Codegen/build |
 | P2 | Pool link intersection observers | Medium on pages with many links | Low | Link/runtime |
@@ -24,6 +23,9 @@ Completed since this note was drafted:
 - Route declaration entrypoints landed in #199 as `entrypoint: true` on top-level routes. The
   generated API is `RouteDeclarations.<RouteName>.make()`, with `RouteDeclarations.make()` still
   returning all top-level route trees.
+- Collision-safe route keys landed in #194. Generated route keys now use a length-prefixed internal
+  encoder that includes field names, missing-versus-empty query param state, and repeated query
+  param values.
 
 ## Measurement Baseline
 
@@ -461,59 +463,33 @@ The key goal is one history listener per router instance, not one per hook.
 
 ## 7. Make Route Keys Collision-Safe
 
-### Current State
+### Landed Shape
 
-Generated route keys concatenate route name, path param values, and query param values without unambiguous delimiters:
-
-- `packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res`
-
-This can alias different parameter sets. For example, `a="bc"` and `a="b", c="c"` style combinations can collapse if multiple fields are concatenated without separators and field names.
-
-It can also mishandle array query params because route key generation currently reads a single query param value for each query field.
-
-### Opportunity
-
-Generate stable, collision-safe route keys.
-
-Possible formats:
-
-- JSON array of `[fieldName, value]` pairs.
-- Length-prefixed segments.
-- URLSearchParams-like stable serialization with sorted keys and repeated array entries.
-
-Example:
+This landed in #194. Generated route keys now use `RelayRouter.Internal.RouteKey`:
 
 ```rescript
-"Root__Todos__Single:" ++ JSON.stringifyAny([
-  ["path", "todoId", todoId],
-  ["query", "showMore", showMore],
-])->Option.getOr("")
+RelayRouter.Internal.RouteKey.make("Root__Todos__Single")
+->RelayRouter.Internal.RouteKey.addPathParam(~name="todoId", ~value)
+->RelayRouter.Internal.RouteKey.addQueryParam(~name="showMore", ~value)
 ```
 
-This is a correctness fix first. It also improves performance predictability because prepared cache entries cannot be accidentally reused across distinct route states.
+The encoder uses length-prefixed segments for route names, field names, scalar values, and repeated
+query param arrays. It distinguishes:
 
-### Implementation Steps
-
-1. Decide route key encoding.
-2. Update `getMakeRouteKeyFn`.
-3. Ensure path params and query params include field names.
-4. Ensure array query params include all values in order or sorted order, depending on desired semantics.
-5. Add tests for:
-   - adjacent string collisions
-   - missing vs empty values
-   - array values
-   - reordered query params if the router treats them as equivalent
-6. Consider whether this is a breaking change for any user-observable behavior. It should be internal, but prepared cache behavior can change.
+- adjacent string boundaries
+- path and query field names
+- missing query params from present empty values
+- repeated query param value boundaries
+- repeated query param order
 
 ### Validation
 
 - Distinct route param sets produce distinct keys.
-- Equivalent query string ordering produces equivalent keys if that is the desired semantic.
+- Repeated query param ordering is preserved as part of the key.
 - Existing preloading cache still works.
 
 ### Risks
 
-- JSON stringification adds minor overhead. It is probably acceptable for correctness, but a length-prefixed string can be faster.
 - If current accidental collisions masked bugs, this can expose them.
 
 ## 8. Route Declaration Entrypoints

--- a/examples/client-rendering/src/routes/__generated__/RouteDeclarations.res
+++ b/examples/client-rendering/src/routes/__generated__/RouteDeclarations.res
@@ -68,7 +68,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
   ): string => {
     ignore(pathParams)
     ignore(queryParams)
-    "Root:"
+    RelayRouter.Internal.RouteKey.make("Root")
   },
         ~routeName,
         ~intent
@@ -134,7 +134,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
       ): string => {
         ignore(pathParams)
         ignore(queryParams)
-        "Root__Settings:"
+        RelayRouter.Internal.RouteKey.make("Root__Settings")
       },
             ~routeName,
             ~intent
@@ -203,10 +203,10 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
         ~queryParams: RelayRouter.Bindings.QueryParams.t
       ): string => {
         ignore(pathParams)
-        "Root__Todos:"
-          ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statuses")->Option.getOr("")
-          ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statusWithDefault")->Option.getOr("")
-          ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("byValue")->Option.getOr("")
+        RelayRouter.Internal.RouteKey.make("Root__Todos")
+        ->RelayRouter.Internal.RouteKey.addQueryParamArray(~name="statuses", ~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("statuses"))
+        ->RelayRouter.Internal.RouteKey.addQueryParam(~name="statusWithDefault", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statusWithDefault"))
+        ->RelayRouter.Internal.RouteKey.addQueryParam(~name="byValue", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("byValue"))
       },
             ~routeName,
             ~intent
@@ -272,11 +272,11 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
               ~pathParams: dict<string>,
               ~queryParams: RelayRouter.Bindings.QueryParams.t
             ): string => {
-              "Root__Todos__ByStatus:"
-                ++ pathParams->Dict.get("byStatus")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statuses")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statusWithDefault")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("byValue")->Option.getOr("")
+              RelayRouter.Internal.RouteKey.make("Root__Todos__ByStatus")
+              ->RelayRouter.Internal.RouteKey.addPathParam(~name="byStatus", ~value=pathParams->Dict.get("byStatus")->Option.getOr(""))
+              ->RelayRouter.Internal.RouteKey.addQueryParamArray(~name="statuses", ~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("statuses"))
+              ->RelayRouter.Internal.RouteKey.addQueryParam(~name="statusWithDefault", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statusWithDefault"))
+              ->RelayRouter.Internal.RouteKey.addQueryParam(~name="byValue", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("byValue"))
             },
                   ~routeName,
                   ~intent
@@ -345,11 +345,11 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
               ~pathParams: dict<string>,
               ~queryParams: RelayRouter.Bindings.QueryParams.t
             ): string => {
-              "Root__Todos__ByStatusDecoded:"
-                ++ pathParams->Dict.get("byStatusDecoded")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statuses")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statusWithDefault")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("byValue")->Option.getOr("")
+              RelayRouter.Internal.RouteKey.make("Root__Todos__ByStatusDecoded")
+              ->RelayRouter.Internal.RouteKey.addPathParam(~name="byStatusDecoded", ~value=pathParams->Dict.get("byStatusDecoded")->Option.getOr(""))
+              ->RelayRouter.Internal.RouteKey.addQueryParamArray(~name="statuses", ~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("statuses"))
+              ->RelayRouter.Internal.RouteKey.addQueryParam(~name="statusWithDefault", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statusWithDefault"))
+              ->RelayRouter.Internal.RouteKey.addQueryParam(~name="byValue", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("byValue"))
             },
                   ~routeName,
                   ~intent
@@ -415,11 +415,11 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
                       ~pathParams: dict<string>,
                       ~queryParams: RelayRouter.Bindings.QueryParams.t
                     ): string => {
-                      "Root__Todos__ByStatusDecoded__Child:"
-                        ++ pathParams->Dict.get("byStatusDecoded")->Option.getOr("")
-                        ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statuses")->Option.getOr("")
-                        ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statusWithDefault")->Option.getOr("")
-                        ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("byValue")->Option.getOr("")
+                      RelayRouter.Internal.RouteKey.make("Root__Todos__ByStatusDecoded__Child")
+                      ->RelayRouter.Internal.RouteKey.addPathParam(~name="byStatusDecoded", ~value=pathParams->Dict.get("byStatusDecoded")->Option.getOr(""))
+                      ->RelayRouter.Internal.RouteKey.addQueryParamArray(~name="statuses", ~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("statuses"))
+                      ->RelayRouter.Internal.RouteKey.addQueryParam(~name="statusWithDefault", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statusWithDefault"))
+                      ->RelayRouter.Internal.RouteKey.addQueryParam(~name="byValue", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("byValue"))
                     },
                           ~routeName,
                           ~intent
@@ -490,11 +490,11 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
               ~pathParams: dict<string>,
               ~queryParams: RelayRouter.Bindings.QueryParams.t
             ): string => {
-              "Root__Todos__ByStatusDecodedExtra:"
-                ++ pathParams->Dict.get("byStatusDecoded")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statuses")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statusWithDefault")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("byValue")->Option.getOr("")
+              RelayRouter.Internal.RouteKey.make("Root__Todos__ByStatusDecodedExtra")
+              ->RelayRouter.Internal.RouteKey.addPathParam(~name="byStatusDecoded", ~value=pathParams->Dict.get("byStatusDecoded")->Option.getOr(""))
+              ->RelayRouter.Internal.RouteKey.addQueryParamArray(~name="statuses", ~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("statuses"))
+              ->RelayRouter.Internal.RouteKey.addQueryParam(~name="statusWithDefault", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statusWithDefault"))
+              ->RelayRouter.Internal.RouteKey.addQueryParam(~name="byValue", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("byValue"))
             },
                   ~routeName,
                   ~intent
@@ -567,12 +567,12 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
               ~pathParams: dict<string>,
               ~queryParams: RelayRouter.Bindings.QueryParams.t
             ): string => {
-              "Root__Todos__Single:"
-                ++ pathParams->Dict.get("todoId")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statuses")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statusWithDefault")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("byValue")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("showMore")->Option.getOr("")
+              RelayRouter.Internal.RouteKey.make("Root__Todos__Single")
+              ->RelayRouter.Internal.RouteKey.addPathParam(~name="todoId", ~value=pathParams->Dict.get("todoId")->Option.getOr(""))
+              ->RelayRouter.Internal.RouteKey.addQueryParamArray(~name="statuses", ~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("statuses"))
+              ->RelayRouter.Internal.RouteKey.addQueryParam(~name="statusWithDefault", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statusWithDefault"))
+              ->RelayRouter.Internal.RouteKey.addQueryParam(~name="byValue", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("byValue"))
+              ->RelayRouter.Internal.RouteKey.addQueryParam(~name="showMore", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("showMore"))
             },
                   ~routeName,
                   ~intent
@@ -642,8 +642,8 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
         ~queryParams: RelayRouter.Bindings.QueryParams.t
       ): string => {
         ignore(queryParams)
-        "Root__PathParamsOnly:"
-          ++ pathParams->Dict.get("pageSlug")->Option.getOr("")
+        RelayRouter.Internal.RouteKey.make("Root__PathParamsOnly")
+        ->RelayRouter.Internal.RouteKey.addPathParam(~name="pageSlug", ~value=pathParams->Dict.get("pageSlug")->Option.getOr(""))
       },
             ~routeName,
             ~intent
@@ -711,7 +711,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
       ): string => {
         ignore(pathParams)
         ignore(queryParams)
-        "Root__Home:"
+        RelayRouter.Internal.RouteKey.make("Root__Home")
       },
             ~routeName,
             ~intent

--- a/examples/express/src/routes/__generated__/RouteDeclarations.res
+++ b/examples/express/src/routes/__generated__/RouteDeclarations.res
@@ -68,7 +68,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
   ): string => {
     ignore(pathParams)
     ignore(queryParams)
-    "Root:"
+    RelayRouter.Internal.RouteKey.make("Root")
   },
         ~routeName,
         ~intent
@@ -133,8 +133,8 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
         ~queryParams: RelayRouter.Bindings.QueryParams.t
       ): string => {
         ignore(pathParams)
-        "Root__Todos:"
-          ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statuses")->Option.getOr("")
+        RelayRouter.Internal.RouteKey.make("Root__Todos")
+        ->RelayRouter.Internal.RouteKey.addQueryParamArray(~name="statuses", ~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("statuses"))
       },
             ~routeName,
             ~intent
@@ -198,9 +198,9 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
               ~pathParams: dict<string>,
               ~queryParams: RelayRouter.Bindings.QueryParams.t
             ): string => {
-              "Root__Todos__ByStatus:"
-                ++ pathParams->Dict.get("byStatus")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statuses")->Option.getOr("")
+              RelayRouter.Internal.RouteKey.make("Root__Todos__ByStatus")
+              ->RelayRouter.Internal.RouteKey.addPathParam(~name="byStatus", ~value=pathParams->Dict.get("byStatus")->Option.getOr(""))
+              ->RelayRouter.Internal.RouteKey.addQueryParamArray(~name="statuses", ~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("statuses"))
             },
                   ~routeName,
                   ~intent
@@ -271,10 +271,10 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
               ~pathParams: dict<string>,
               ~queryParams: RelayRouter.Bindings.QueryParams.t
             ): string => {
-              "Root__Todos__Single:"
-                ++ pathParams->Dict.get("todoId")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("statuses")->Option.getOr("")
-                ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("showMore")->Option.getOr("")
+              RelayRouter.Internal.RouteKey.make("Root__Todos__Single")
+              ->RelayRouter.Internal.RouteKey.addPathParam(~name="todoId", ~value=pathParams->Dict.get("todoId")->Option.getOr(""))
+              ->RelayRouter.Internal.RouteKey.addQueryParamArray(~name="statuses", ~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("statuses"))
+              ->RelayRouter.Internal.RouteKey.addQueryParam(~name="showMore", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("showMore"))
             },
                   ~routeName,
                   ~intent

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res
@@ -444,35 +444,37 @@ let getMakePrepareProps = (route: printableRoute, ~returnMode) => {
 // initialized with. Used to identify a route, make sure it can be prepared,
 // cached, and cleaned up, etc.
 let getMakeRouteKeyFn = (route: printableRoute) => {
-  let {pathParamsRecordFields, queryParamsRecordFields} = getRouteParamRecordFields(route)
+  let pathParams = route.params->Array.map(Utils.printablePathParamToParamName)
+  let queryParams = route.queryParams->Dict.toArray
   let ignoreLines = [
-    switch pathParamsRecordFields->Array.length {
+    switch pathParams->Array.length {
     | 0 => Some("  ignore(pathParams)")
     | _ => None
     },
-    switch queryParamsRecordFields->Array.length {
+    switch queryParams->Array.length {
     | 0 => Some("  ignore(queryParams)")
     | _ => None
     },
   ]->Array.filterMap(line => line)
-  let pathParamLines =
-    pathParamsRecordFields->Array.map(((key, _)) =>
-      "    ++ pathParams->Dict.get(\"" ++ key ++ "\")->Option.getOr(\"\")"
-    )
-  let queryParamLines =
-    queryParamsRecordFields->Array.map(((key, _)) =>
-      "    ++ queryParams->RelayRouter.Bindings.QueryParams.getParamByKey(\"" ++
-      key ++ "\")->Option.getOr(\"\")"
-    )
-  let bodyLines =
-    List.concatMany([
-      ignoreLines->List.fromArray,
-      list{`  "${route.name->RouteName.getFullRouteName}:"`},
-      pathParamLines->List.fromArray,
-      queryParamLines->List.fromArray,
-    ])
-    ->List.toArray
-    ->Array.join("\n")
+  let pathParamLines = pathParams->Array.map(key =>
+    `  ->RelayRouter.Internal.RouteKey.addPathParam(~name="${key}", ~value=pathParams->Dict.get("${key}")->Option.getOr(""))`
+  )
+  let queryParamLines = queryParams->Array.map(((key, param)) =>
+    switch param {
+    | Array(_) =>
+      `  ->RelayRouter.Internal.RouteKey.addQueryParamArray(~name="${key}", ~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("${key}"))`
+    | _ =>
+      `  ->RelayRouter.Internal.RouteKey.addQueryParam(~name="${key}", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("${key}"))`
+    }
+  )
+  let bodyLines = List.concatMany([
+    ignoreLines->List.fromArray,
+    list{`  RelayRouter.Internal.RouteKey.make("${route.name->RouteName.getFullRouteName}")`},
+    pathParamLines->List.fromArray,
+    queryParamLines->List.fromArray,
+  ])
+  ->List.toArray
+  ->Array.join("\n")
 
   `(
   ~pathParams: dict<string>,
@@ -499,7 +501,6 @@ let getPathParamsTypeDefinition = (route: printableRoute) => {
 
   str.contents
 }
-
 let getUsePathParamsHook = (route: printableRoute) => {
   let str = ref("")
 

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res
@@ -456,9 +456,10 @@ let getMakeRouteKeyFn = (route: printableRoute) => {
     | _ => None
     },
   ]->Array.filterMap(line => line)
-  let pathParamLines = pathParams->Array.map(key =>
-    `  ->RelayRouter.Internal.RouteKey.addPathParam(~name="${key}", ~value=pathParams->Dict.get("${key}")->Option.getOr(""))`
-  )
+  let pathParamLines =
+    pathParams->Array.map(key =>
+      `  ->RelayRouter.Internal.RouteKey.addPathParam(~name="${key}", ~value=pathParams->Dict.get("${key}")->Option.getOr(""))`
+    )
   let queryParamLines = queryParams->Array.map(((key, param)) =>
     switch param {
     | Array(_) =>
@@ -467,14 +468,15 @@ let getMakeRouteKeyFn = (route: printableRoute) => {
       `  ->RelayRouter.Internal.RouteKey.addQueryParam(~name="${key}", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("${key}"))`
     }
   )
-  let bodyLines = List.concatMany([
-    ignoreLines->List.fromArray,
-    list{`  RelayRouter.Internal.RouteKey.make("${route.name->RouteName.getFullRouteName}")`},
-    pathParamLines->List.fromArray,
-    queryParamLines->List.fromArray,
-  ])
-  ->List.toArray
-  ->Array.join("\n")
+  let bodyLines =
+    List.concatMany([
+      ignoreLines->List.fromArray,
+      list{`  RelayRouter.Internal.RouteKey.make("${route.name->RouteName.getFullRouteName}")`},
+      pathParamLines->List.fromArray,
+      queryParamLines->List.fromArray,
+    ])
+    ->List.toArray
+    ->Array.join("\n")
 
   `(
   ~pathParams: dict<string>,

--- a/packages/rescript-relay-router/src/RelayRouter__Internal.res
+++ b/packages/rescript-relay-router/src/RelayRouter__Internal.res
@@ -121,29 +121,25 @@ external toObject: Type.Classify.object => {..} = "%identity"
 external objectToPreparedArrayUnsafe: Type.Classify.object => array<prepared> = "%identity"
 
 module RouteKey = {
-  let encodeString = value => Int.toString(value->String.length) ++ ":" ++ value
+  let encodeString = value => `${value->String.length->Int.toString}:${value}`
 
   let encodeValues = values =>
     switch values {
     | None => "-1:"
     | Some(values) =>
-      Int.toString(values->Array.length) ++ ":" ++ values->Array.map(encodeString)->Array.join("")
+      `${values->Array.length->Int.toString}:${values->Array.map(encodeString)->Array.join("")}`
     }
 
-  let make = routeName => "route:" ++ encodeString(routeName)
+  let make = routeName => `route:${encodeString(routeName)}`
 
   let addPathParam = (key, ~name, ~value) =>
-    key ++ "|path:" ++ encodeString(name) ++ ":" ++ encodeValues(Some([value]))
+    `${key}|path:${encodeString(name)}:${encodeValues(Some([value]))}`
 
   let addQueryParam = (key, ~name, ~value) =>
-    key ++
-    "|query:" ++
-    encodeString(name) ++
-    ":" ++
-    encodeValues(value->Option.map(value => [value]))
+    `${key}|query:${encodeString(name)}:${encodeValues(value->Option.map(value => [value]))}`
 
   let addQueryParamArray = (key, ~name, ~values) =>
-    key ++ "|query:" ++ encodeString(name) ++ ":" ++ encodeValues(values)
+    `${key}|query:${encodeString(name)}:${encodeValues(values)}`
 }
 
 // This will extract all dispose functions from anything you feed it.

--- a/packages/rescript-relay-router/src/RelayRouter__Internal.res
+++ b/packages/rescript-relay-router/src/RelayRouter__Internal.res
@@ -120,6 +120,32 @@ type prepared
 external toObject: Type.Classify.object => {..} = "%identity"
 external objectToPreparedArrayUnsafe: Type.Classify.object => array<prepared> = "%identity"
 
+module RouteKey = {
+  let encodeString = value => Int.toString(value->String.length) ++ ":" ++ value
+
+  let encodeValues = values =>
+    switch values {
+    | None => "-1:"
+    | Some(values) =>
+      Int.toString(values->Array.length) ++ ":" ++ values->Array.map(encodeString)->Array.join("")
+    }
+
+  let make = routeName => "route:" ++ encodeString(routeName)
+
+  let addPathParam = (key, ~name, ~value) =>
+    key ++ "|path:" ++ encodeString(name) ++ ":" ++ encodeValues(Some([value]))
+
+  let addQueryParam = (key, ~name, ~value) =>
+    key ++
+    "|query:" ++
+    encodeString(name) ++
+    ":" ++
+    encodeValues(value->Option.map(value => [value]))
+
+  let addQueryParamArray = (key, ~name, ~values) =>
+    key ++ "|query:" ++ encodeString(name) ++ ":" ++ encodeValues(values)
+}
+
 // This will extract all dispose functions from anything you feed it.
 let extractDisposables = prepared => {
   let rec aux = (s, disposables, seen) => {

--- a/packages/rescript-relay-router/src/RelayRouter__Internal.resi
+++ b/packages/rescript-relay-router/src/RelayRouter__Internal.resi
@@ -36,6 +36,14 @@ external matchPathWithOptions: ({"path": string, "end": bool}, string) => option
   "matchPath"
 
 type prepared
+
+module RouteKey: {
+  let make: string => string
+  let addPathParam: (string, ~name: string, ~value: string) => string
+  let addQueryParam: (string, ~name: string, ~value: option<string>) => string
+  let addQueryParamArray: (string, ~name: string, ~values: option<array<string>>) => string
+}
+
 let extractDisposables: prepared => array<unit => unit>
 
 let runAtPriority: (

--- a/packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res
+++ b/packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res
@@ -64,6 +64,14 @@ let sliceBetween = (content, ~startMarker, ~endMarker) => {
   content->slice(start, end_)
 }
 
+let withSinglePrintableRoute = (routesJson, callback) => {
+  let {result} = TestUtils.parseMockContent(routesJson)
+  switch result->U.routeChildrenToPrintable {
+  | [route] => callback(route)
+  | routes => expect(routes->Array.length)->Expect.toBe(1)
+  }
+}
+
 describe("Query params", () => {
   test("turns param type to string", _t => {
     open U.QueryParams
@@ -296,84 +304,96 @@ describe("Route declarations", () => {
 
 describe("Route key codegen", () => {
   test("emits path params through the collision-safe route key encoder", _t => {
-    let route = parseOnlyPrintableRoute(`[
+    withSinglePrintableRoute(
+      `[
       {
         "name": "Root",
         "path": "/:first/:second"
       }
-    ]`)
+    ]`,
+      route => {
+        let generated = RescriptRelayRouterCli__Codegen.getRouteDefinition(route, ~indentation=0)
 
-    let generated = Codegen.getRouteDefinition(route, ~indentation=0)
-
-    generated->expectStringToContain(`RelayRouter.Internal.RouteKey.make("Root")`)
-    generated->expectStringToContain(
-      `RelayRouter.Internal.RouteKey.addPathParam(~name="first"`,
-    )
-    generated->expectStringToContain(
-      `RelayRouter.Internal.RouteKey.addPathParam(~name="second"`,
+        expect(generated)->Expect.String.toContain(`RelayRouter.Internal.RouteKey.make("Root")`)
+        expect(
+          generated,
+        )->Expect.String.toContain(`RelayRouter.Internal.RouteKey.addPathParam(~name="first"`)
+        expect(
+          generated,
+        )->Expect.String.toContain(`RelayRouter.Internal.RouteKey.addPathParam(~name="second"`)
+      },
     )
   })
 
   test("emits scalar query params with explicit missing versus empty encoding", _t => {
-    let route = parseOnlyPrintableRoute(`[
+    withSinglePrintableRoute(
+      `[
       {
         "name": "Root",
         "path": "/?first=string&second=string"
       }
-    ]`)
+    ]`,
+      route => {
+        let generated = RescriptRelayRouterCli__Codegen.getRouteDefinition(route, ~indentation=0)
 
-    let generated = Codegen.getRouteDefinition(route, ~indentation=0)
-
-    generated->expectStringToContain(
-      `RelayRouter.Internal.RouteKey.addQueryParam(~name="first"`,
-    )
-    generated->expectStringToContain(
-      `~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("first")`,
-    )
-    generated->expectStringToContain(
-      `RelayRouter.Internal.RouteKey.addQueryParam(~name="second"`,
-    )
-    generated->expectStringToContain(
-      `~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("second")`,
+        expect(
+          generated,
+        )->Expect.String.toContain(`RelayRouter.Internal.RouteKey.addQueryParam(~name="first"`)
+        expect(
+          generated,
+        )->Expect.String.toContain(`~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("first")`)
+        expect(
+          generated,
+        )->Expect.String.toContain(`RelayRouter.Internal.RouteKey.addQueryParam(~name="second"`)
+        expect(
+          generated,
+        )->Expect.String.toContain(`~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("second")`)
+      },
     )
   })
 
   test("emits array query params using all repeated values", _t => {
-    let route = parseOnlyPrintableRoute(`[
+    withSinglePrintableRoute(
+      `[
       {
         "name": "Root",
         "path": "/?statuses=array<string>&after=string"
       }
-    ]`)
+    ]`,
+      route => {
+        let generated = RescriptRelayRouterCli__Codegen.getRouteDefinition(route, ~indentation=0)
 
-    let generated = Codegen.getRouteDefinition(route, ~indentation=0)
-
-    generated->expectStringToContain(
-      `RelayRouter.Internal.RouteKey.addQueryParamArray(~name="statuses"`,
-    )
-    generated->expectStringToContain(
-      `~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("statuses")`,
-    )
-    generated->expectStringToContain(
-      `RelayRouter.Internal.RouteKey.addQueryParam(~name="after"`,
+        expect(
+          generated,
+        )->Expect.String.toContain(`RelayRouter.Internal.RouteKey.addQueryParamArray(~name="statuses"`)
+        expect(
+          generated,
+        )->Expect.String.toContain(`~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("statuses")`)
+        expect(
+          generated,
+        )->Expect.String.toContain(`RelayRouter.Internal.RouteKey.addQueryParam(~name="after"`)
+      },
     )
   })
 
   test("uses original URL param names when generated prop names need collision protection", _t => {
-    let route = parseOnlyPrintableRoute(`[
+    withSinglePrintableRoute(
+      `[
       {
         "name": "Root",
         "path": "/:environment?pathParams=string"
       }
-    ]`)
+    ]`,
+      route => {
+        let generated = RescriptRelayRouterCli__Codegen.getRouteDefinition(route, ~indentation=0)
 
-    let generated = Codegen.getRouteDefinition(route, ~indentation=0)
-
-    generated->expectStringToContain(
-      `RelayRouter.Internal.RouteKey.addPathParam(~name="environment", ~value=pathParams->Dict.get("environment")->Option.getOr(""))`,
-    )
-    generated->expectStringToContain(
-      `RelayRouter.Internal.RouteKey.addQueryParam(~name="pathParams", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("pathParams"))`,
+        expect(
+          generated,
+        )->Expect.String.toContain(`RelayRouter.Internal.RouteKey.addPathParam(~name="environment", ~value=pathParams->Dict.get("environment")->Option.getOr(""))`)
+        expect(
+          generated,
+        )->Expect.String.toContain(`RelayRouter.Internal.RouteKey.addQueryParam(~name="pathParams", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("pathParams"))`)
+      },
     )
   })
 })

--- a/packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res
+++ b/packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res
@@ -294,6 +294,90 @@ describe("Route declarations", () => {
   })
 })
 
+describe("Route key codegen", () => {
+  test("emits path params through the collision-safe route key encoder", _t => {
+    let route = parseOnlyPrintableRoute(`[
+      {
+        "name": "Root",
+        "path": "/:first/:second"
+      }
+    ]`)
+
+    let generated = Codegen.getRouteDefinition(route, ~indentation=0)
+
+    generated->expectStringToContain(`RelayRouter.Internal.RouteKey.make("Root")`)
+    generated->expectStringToContain(
+      `RelayRouter.Internal.RouteKey.addPathParam(~name="first"`,
+    )
+    generated->expectStringToContain(
+      `RelayRouter.Internal.RouteKey.addPathParam(~name="second"`,
+    )
+  })
+
+  test("emits scalar query params with explicit missing versus empty encoding", _t => {
+    let route = parseOnlyPrintableRoute(`[
+      {
+        "name": "Root",
+        "path": "/?first=string&second=string"
+      }
+    ]`)
+
+    let generated = Codegen.getRouteDefinition(route, ~indentation=0)
+
+    generated->expectStringToContain(
+      `RelayRouter.Internal.RouteKey.addQueryParam(~name="first"`,
+    )
+    generated->expectStringToContain(
+      `~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("first")`,
+    )
+    generated->expectStringToContain(
+      `RelayRouter.Internal.RouteKey.addQueryParam(~name="second"`,
+    )
+    generated->expectStringToContain(
+      `~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("second")`,
+    )
+  })
+
+  test("emits array query params using all repeated values", _t => {
+    let route = parseOnlyPrintableRoute(`[
+      {
+        "name": "Root",
+        "path": "/?statuses=array<string>&after=string"
+      }
+    ]`)
+
+    let generated = Codegen.getRouteDefinition(route, ~indentation=0)
+
+    generated->expectStringToContain(
+      `RelayRouter.Internal.RouteKey.addQueryParamArray(~name="statuses"`,
+    )
+    generated->expectStringToContain(
+      `~values=queryParams->RelayRouter.Bindings.QueryParams.getArrayParamByKey("statuses")`,
+    )
+    generated->expectStringToContain(
+      `RelayRouter.Internal.RouteKey.addQueryParam(~name="after"`,
+    )
+  })
+
+  test("uses original URL param names when generated prop names need collision protection", _t => {
+    let route = parseOnlyPrintableRoute(`[
+      {
+        "name": "Root",
+        "path": "/:environment?pathParams=string"
+      }
+    ]`)
+
+    let generated = Codegen.getRouteDefinition(route, ~indentation=0)
+
+    generated->expectStringToContain(
+      `RelayRouter.Internal.RouteKey.addPathParam(~name="environment", ~value=pathParams->Dict.get("environment")->Option.getOr(""))`,
+    )
+    generated->expectStringToContain(
+      `RelayRouter.Internal.RouteKey.addQueryParam(~name="pathParams", ~value=queryParams->RelayRouter.Bindings.QueryParams.getParamByKey("pathParams"))`,
+    )
+  })
+})
+
 describe("Dump routes", () => {
   test("returns all routes in definition order by default", _t => {
     let {result} = TestUtils.parseMockContent(`[

--- a/packages/rescript-relay-router/test/RouterUtils.test.res
+++ b/packages/rescript-relay-router/test/RouterUtils.test.res
@@ -90,72 +90,90 @@ describe("RelayRouter__Internal.RouteKey", () => {
 
   test("distinguishes path param field names", _t => {
     let key1 =
-      RelayRouter__Internal.RouteKey.make("Root")
-      ->RelayRouter__Internal.RouteKey.addPathParam(~name="first", ~value="same")
+      RelayRouter__Internal.RouteKey.make("Root")->RelayRouter__Internal.RouteKey.addPathParam(
+        ~name="first",
+        ~value="same",
+      )
 
     let key2 =
-      RelayRouter__Internal.RouteKey.make("Root")
-      ->RelayRouter__Internal.RouteKey.addPathParam(~name="second", ~value="same")
+      RelayRouter__Internal.RouteKey.make("Root")->RelayRouter__Internal.RouteKey.addPathParam(
+        ~name="second",
+        ~value="same",
+      )
 
     expect(key1 === key2)->Expect.toBe(false)
   })
 
   test("distinguishes missing query params from empty query params", _t => {
     let key1 =
-      RelayRouter__Internal.RouteKey.make("Root")
-      ->RelayRouter__Internal.RouteKey.addQueryParam(~name="first", ~value=None)
+      RelayRouter__Internal.RouteKey.make("Root")->RelayRouter__Internal.RouteKey.addQueryParam(
+        ~name="first",
+        ~value=None,
+      )
 
     let key2 =
-      RelayRouter__Internal.RouteKey.make("Root")
-      ->RelayRouter__Internal.RouteKey.addQueryParam(~name="first", ~value=Some(""))
+      RelayRouter__Internal.RouteKey.make("Root")->RelayRouter__Internal.RouteKey.addQueryParam(
+        ~name="first",
+        ~value=Some(""),
+      )
 
     expect(key1 === key2)->Expect.toBe(false)
   })
 
   test("distinguishes scalar query param field names", _t => {
     let key1 =
-      RelayRouter__Internal.RouteKey.make("Root")
-      ->RelayRouter__Internal.RouteKey.addQueryParam(~name="first", ~value=Some("same"))
+      RelayRouter__Internal.RouteKey.make("Root")->RelayRouter__Internal.RouteKey.addQueryParam(
+        ~name="first",
+        ~value=Some("same"),
+      )
 
     let key2 =
-      RelayRouter__Internal.RouteKey.make("Root")
-      ->RelayRouter__Internal.RouteKey.addQueryParam(~name="second", ~value=Some("same"))
+      RelayRouter__Internal.RouteKey.make("Root")->RelayRouter__Internal.RouteKey.addQueryParam(
+        ~name="second",
+        ~value=Some("same"),
+      )
 
     expect(key1 === key2)->Expect.toBe(false)
   })
 
   test("distinguishes repeated query param value boundaries", _t => {
     let key1 =
-      RelayRouter__Internal.RouteKey.make("Root")
-      ->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some(["a", "bc"]))
+      RelayRouter__Internal.RouteKey.make(
+        "Root",
+      )->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some(["a", "bc"]))
 
     let key2 =
-      RelayRouter__Internal.RouteKey.make("Root")
-      ->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some(["ab", "c"]))
+      RelayRouter__Internal.RouteKey.make(
+        "Root",
+      )->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some(["ab", "c"]))
 
     expect(key1 === key2)->Expect.toBe(false)
   })
 
   test("preserves repeated query param order", _t => {
     let key1 =
-      RelayRouter__Internal.RouteKey.make("Root")
-      ->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some(["a", "b"]))
+      RelayRouter__Internal.RouteKey.make(
+        "Root",
+      )->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some(["a", "b"]))
 
     let key2 =
-      RelayRouter__Internal.RouteKey.make("Root")
-      ->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some(["b", "a"]))
+      RelayRouter__Internal.RouteKey.make(
+        "Root",
+      )->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some(["b", "a"]))
 
     expect(key1 === key2)->Expect.toBe(false)
   })
 
   test("distinguishes missing repeated query params from present empty arrays", _t => {
     let key1 =
-      RelayRouter__Internal.RouteKey.make("Root")
-      ->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=None)
+      RelayRouter__Internal.RouteKey.make(
+        "Root",
+      )->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=None)
 
     let key2 =
-      RelayRouter__Internal.RouteKey.make("Root")
-      ->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some([]))
+      RelayRouter__Internal.RouteKey.make(
+        "Root",
+      )->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some([]))
 
     expect(key1 === key2)->Expect.toBe(false)
   })

--- a/packages/rescript-relay-router/test/RouterUtils.test.res
+++ b/packages/rescript-relay-router/test/RouterUtils.test.res
@@ -72,3 +72,91 @@ describe("RelayRouter__Utils", () => {
     )
   })
 })
+
+describe("RelayRouter__Internal.RouteKey", () => {
+  test("distinguishes adjacent path param values that concatenate to the same string", _t => {
+    let key1 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addPathParam(~name="first", ~value="a")
+      ->RelayRouter__Internal.RouteKey.addPathParam(~name="second", ~value="bc")
+
+    let key2 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addPathParam(~name="first", ~value="ab")
+      ->RelayRouter__Internal.RouteKey.addPathParam(~name="second", ~value="c")
+
+    expect(key1 === key2)->Expect.toBe(false)
+  })
+
+  test("distinguishes path param field names", _t => {
+    let key1 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addPathParam(~name="first", ~value="same")
+
+    let key2 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addPathParam(~name="second", ~value="same")
+
+    expect(key1 === key2)->Expect.toBe(false)
+  })
+
+  test("distinguishes missing query params from empty query params", _t => {
+    let key1 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addQueryParam(~name="first", ~value=None)
+
+    let key2 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addQueryParam(~name="first", ~value=Some(""))
+
+    expect(key1 === key2)->Expect.toBe(false)
+  })
+
+  test("distinguishes scalar query param field names", _t => {
+    let key1 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addQueryParam(~name="first", ~value=Some("same"))
+
+    let key2 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addQueryParam(~name="second", ~value=Some("same"))
+
+    expect(key1 === key2)->Expect.toBe(false)
+  })
+
+  test("distinguishes repeated query param value boundaries", _t => {
+    let key1 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some(["a", "bc"]))
+
+    let key2 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some(["ab", "c"]))
+
+    expect(key1 === key2)->Expect.toBe(false)
+  })
+
+  test("preserves repeated query param order", _t => {
+    let key1 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some(["a", "b"]))
+
+    let key2 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some(["b", "a"]))
+
+    expect(key1 === key2)->Expect.toBe(false)
+  })
+
+  test("distinguishes missing repeated query params from present empty arrays", _t => {
+    let key1 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=None)
+
+    let key2 =
+      RelayRouter__Internal.RouteKey.make("Root")
+      ->RelayRouter__Internal.RouteKey.addQueryParamArray(~name="tags", ~values=Some([]))
+
+    expect(key1 === key2)->Expect.toBe(false)
+  })
+})

--- a/plans/2026-05-19-collision-safe-route-keys.md
+++ b/plans/2026-05-19-collision-safe-route-keys.md
@@ -1,0 +1,34 @@
+# Collision-Safe Route Keys
+
+## Decision
+
+Generated route keys should be built through `RelayRouter.Internal.RouteKey` instead of direct string
+concatenation. The key format uses length-prefixed route names, path param names and values, query
+param names and values, and repeated query param arrays.
+
+## Who
+
+zth-linzumi asked Codex to take `fix/collision-safe-route-keys` through to a merge-ready PR after
+the route matching optimization landed. Codex rebased the branch onto latest `main`, skipped the
+already-merged optimization-doc commit, and adapted the fix to the newer route slots and route
+declaration entrypoint codegen.
+
+## Why
+
+The old generated route keys concatenated param values without unambiguous field boundaries. That
+could let distinct route states share one prepared cache key. The new encoder includes names,
+missing-versus-empty state, value boundaries, and repeated query param values.
+
+## Verification
+
+- Unit tests cover adjacent path param collisions.
+- Unit tests cover path and query field names.
+- Unit tests cover missing versus empty query params.
+- Unit tests cover repeated query param value boundaries and order.
+- Codegen tests cover path params, scalar query params, array query params, and original URL param
+  names when generated prop names need collision protection.
+
+## Non-Goals
+
+- This does not normalize repeated query param order; order remains part of the key.
+- This does not change public route config syntax.


### PR DESCRIPTION
## Summary

- Generate prepared route keys through `RelayRouter.Internal.RouteKey` instead of direct string concatenation.
- Include route names, path param names/values, scalar query param names/values, missing-versus-empty state, and repeated query param arrays in the encoded key.
- Regenerate the sample route declarations so they use the collision-safe key builder.
- Update the optimization note, add a decision note, and add a patch changeset.

## Validation

- `yarn workspaces foreach run rescript format -all`
- `yarn build`
- `yarn test`
- `yarn install --immutable`
- `yarn changeset status --since origin/main`
- `git diff --check`
