### PR TITLE
[codex] Precompile route matching

### DIFF
--- a/.changeset/precompile-route-matching.md
+++ b/.changeset/precompile-route-matching.md
@@ -1,0 +1,5 @@
+---
+"rescript-relay-router": patch
+---
+
+Precompile route matching metadata once per router instance instead of flattening, ranking, and compiling path patterns for every match.

--- a/docs/router-optimization-opportunities.md
+++ b/docs/router-optimization-opportunities.md
@@ -13,12 +13,17 @@ The intent is that each section can be picked up as an independent work item. So
 | P1 | Reuse unchanged prepared matches with explicit freshness policy | High for nested routes with parent queries | High | Relay/runtime |
 | P1 | Centralize location subscriptions | Medium to high in nav-heavy UIs | Medium | React runtime |
 | P1 | Make route keys collision-safe | Correctness fix with cache perf implications | Low | Codegen |
-| P1 | Support rendering one named root-level route tree | High for multi-entry apps and embedded surfaces | Medium | Codegen/runtime |
 | P2 | Split route declaration payload from route prepare modules | High in very large apps | High | Codegen/build |
 | P2 | Verify and improve renderer chunk boundaries | Medium bundle-size opportunity | Medium | Codegen/build |
 | P2 | Pool link intersection observers | Medium on pages with many links | Low | Link/runtime |
 | P2 | Replace reflective disposable extraction | Medium runtime + API robustness | Medium | Relay/runtime API |
 | P3 | Reduce repeated query decoding | Medium in query-heavy route trees | Medium | Codegen/runtime |
+
+Completed since this note was drafted:
+
+- Route declaration entrypoints landed in #199 as `entrypoint: true` on top-level routes. The
+  generated API is `RouteDeclarations.<RouteName>.make()`, with `RouteDeclarations.make()` still
+  returning all top-level route trees.
 
 ## Measurement Baseline
 
@@ -511,7 +516,7 @@ This is a correctness fix first. It also improves performance predictability bec
 - JSON stringification adds minor overhead. It is probably acceptable for correctness, but a length-prefixed string can be faster.
 - If current accidental collisions masked bugs, this can expose them.
 
-## 8. Support Rendering One Named Root-Level Route Tree
+## 8. Route Declaration Entrypoints
 
 ### Use Case
 
@@ -546,68 +551,29 @@ The desired behavior is to load and render only one of those root-level trees in
 
 This is related to code splitting, but it is a distinct requirement. The goal is not only to code split route renderers after matching. The goal is to make the top-level route tree itself a selectable render and build boundary.
 
-### Current State
+### Landed Shape
 
-The parser reads `routes.json` as an array of top-level routes:
+This landed in #199 as route declaration entrypoints. Top-level routes can opt into a generated
+standalone declaration module with `entrypoint: true`:
 
-- `packages/rescript-relay-router/cli/RescriptRelayRouterCli__Parser.res`
-- `packages/rescript-relay-router/cli/RescriptRelayRouterCli__Types.res`
-
-The generated `RouteDeclarations.make()` returns all top-level route trees as one `array<RelayRouter.Types.route>`.
-
-`RelayRouter.RouteRenderer` renders the current router entry's full matched branch:
-
-- `packages/rescript-relay-router/src/RelayRouter.res`
-
-That works well for a single app-wide router. It does not give an ergonomic way to say "construct, match, preload, and render only the `Admin` top-level tree".
-
-### Opportunity
-
-Introduce named root route trees as a first-class generated concept.
-
-At minimum, codegen should expose each top-level route tree independently. Possible API shapes:
-
-```rescript
-let routes = RouteDeclarations.makeRoot(~root=#Admin)
+```json
+{
+  "path": "/admin",
+  "name": "Admin",
+  "entrypoint": true,
+  "children": []
+}
 ```
 
-or:
+The generated route declaration construction API is:
 
 ```rescript
 let routes = RouteDeclarations.Admin.make()
 ```
 
-or:
+`RouteDeclarations.make()` remains the backwards-compatible all-routes API.
 
-```rescript
-let routes = RouteDeclarations.make(~roots=[#Admin])
-```
-
-The route name should likely come from the existing top-level `name` field. A top-level route named `Admin` becomes a selectable root tree named `#Admin`.
-
-This unlocks several patterns:
-
-- Create separate router contexts per entrypoint, each with only the relevant root tree.
-- Build separate client bundles that import only the relevant generated root-tree maker.
-- Keep type-safe route helpers for all routes available when desired, while allowing runtime declarations to be scoped.
-- Combine with lazy route declaration splitting later so importing `Admin.make()` does not pull `Root` and `Embedded` runtime declarations into the same bundle.
-
-### API Design Considerations
-
-There are two related but separate APIs:
-
-1. Route declaration construction.
-2. Route rendering from an existing router context.
-
-For route declaration construction, prefer a generated module per top-level route:
-
-```rescript
-let routes = RouteDeclarations.Admin.make()
-```
-
-This is friendlier to bundlers than a single `make(~root=#Admin)` switch because static imports can point at one generated module. It also leaves room for each top-level tree to live in its own generated file later.
-
-For route rendering, prefer keeping `RouteRenderer` simple and context-driven:
+Route rendering remains context-driven:
 
 ```rescript
 let (_, routerContext) = RelayRouter.Router.make(
@@ -620,38 +586,8 @@ let (_, routerContext) = RelayRouter.Router.make(
 </RelayRouter.Provider>
 ```
 
-An optional `RouteRenderer(~root=...)` prop is possible, but it is less clean because matching and preloading would still have happened against the broader route tree. Filtering at render time would save less work and could create confusing behavior where links preload routes the renderer will not show.
-
-### Implementation Steps
-
-1. Identify top-level route entries during codegen.
-2. Generate a module for each top-level route tree:
-
-   ```rescript
-   module Root = {
-     let make = (~prepareDisposeTimeout=?) => [rootRoute]
-   }
-
-   module Admin = {
-     let make = (~prepareDisposeTimeout=?) => [adminRoute]
-   }
-
-   module Embedded = {
-     let make = (~prepareDisposeTimeout=?) => [embeddedRoute]
-   }
-   ```
-
-3. Keep the current `RouteDeclarations.make()` API as the backwards-compatible "all roots" entrypoint.
-4. Ensure generated top-level modules share the same loaded route renderer cache only when that is desired.
-   - If multiple router contexts can exist on one page, a shared cache may be beneficial for code imports.
-   - Prepared route caches should remain scoped per `make()` result/router instance.
-5. Add generated signatures in `RouteDeclarations.resi`.
-6. Update README examples to show:
-   - all routes
-   - one named root tree
-   - separate app entrypoints using separate generated root modules
-7. Add codegen tests that verify generated modules exist for multiple top-level route entries.
-8. Add runtime tests or example coverage for creating a router with only one named root tree.
+This is preferable to render-time filtering because it scopes matching, preloading, preparation, and
+rendering consistently. A `RouteRenderer(~root=...)` prop would filter too late.
 
 ### Code Splitting Follow-Up
 

--- a/docs/router-optimization-opportunities.md
+++ b/docs/router-optimization-opportunities.md
@@ -1,0 +1,942 @@
+# Router Optimization Opportunities
+
+This document captures a holistic pass over `rescript-relay-router` with a focus on runtime performance, bundle shape, code splitting, SSR asset loading, and maintainability of the hot paths.
+
+The intent is that each section can be picked up as an independent work item. Some items are direct optimizations with low semantic risk. Others are architectural directions that should start with measurement or a narrow proof of concept.
+
+## Priority Overview
+
+| Priority | Area | Expected impact | Risk | Suggested owner |
+| --- | --- | --- | --- | --- |
+| P0 | Precompile route matching | High for large route trees and link-heavy pages | Medium | Runtime/router |
+| P0 | Centralize manifest-backed asset preloading | High for SSR, hydration, and route transitions | Medium | SSR/build integration |
+| P1 | Reuse unchanged prepared matches with explicit freshness policy | High for nested routes with parent queries | High | Relay/runtime |
+| P1 | Centralize location subscriptions | Medium to high in nav-heavy UIs | Medium | React runtime |
+| P1 | Make route keys collision-safe | Correctness fix with cache perf implications | Low | Codegen |
+| P1 | Support rendering one named root-level route tree | High for multi-entry apps and embedded surfaces | Medium | Codegen/runtime |
+| P2 | Split route declaration payload from route prepare modules | High in very large apps | High | Codegen/build |
+| P2 | Verify and improve renderer chunk boundaries | Medium bundle-size opportunity | Medium | Codegen/build |
+| P2 | Pool link intersection observers | Medium on pages with many links | Low | Link/runtime |
+| P2 | Replace reflective disposable extraction | Medium runtime + API robustness | Medium | Relay/runtime API |
+| P3 | Reduce repeated query decoding | Medium in query-heavy route trees | Medium | Codegen/runtime |
+
+## Measurement Baseline
+
+Before changing behavior, add a repeatable way to measure the current costs:
+
+- Build a synthetic route tree with tens, hundreds, and thousands of routes.
+- Include nested routes, static routes, dynamic params, regex path params, splats if supported, and query-param-heavy routes.
+- Render pages with many `RelayRouter.Link` instances using `OnInView`, `OnIntent`, and `OnRender`.
+- Measure client navigation time from history event to first render attempt.
+- Measure number of `prepare` calls per navigation.
+- Measure number of history listeners on a page with many active route hooks.
+- Measure client bundle size and chunk graph for a realistic app.
+- Measure SSR output for preload tag duplication, preload ordering, and hydration timing.
+
+Suggested test fixtures:
+
+- Extend `packages/rescript-relay-router/test/RouterUtils.test.res` for pure route matching and route-key behavior.
+- Add focused tests around generated output in `packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res`.
+- Add a larger example or benchmark fixture under `examples/` only if it exercises Vite chunk output or SSR manifest behavior.
+
+Use this baseline to prevent a common failure mode: making the router theoretically cleaner while moving cost from one phase to another without observing the final app behavior.
+
+## 1. Precompile Route Matching
+
+### Current State
+
+Route matching is delegated to the vendored React Router helper:
+
+- `packages/rescript-relay-router/src/vendor/react-router.js`
+- `packages/rescript-relay-router/src/RelayRouter.res`
+
+`matchRoutes` currently performs work every time it is called:
+
+- It flattens the full route tree.
+- It ranks branches.
+- It computes path scores.
+- It compiles path regexes through `matchPath` while trying branches.
+
+The router calls this in several hot paths:
+
+- Initial route matching in `Router.make`.
+- Every history update.
+- Every `preload` and `preloadCode` call, including link intent and in-view preloads.
+
+This means pages with many links can repeatedly flatten and sort the exact same static route tree.
+
+### Opportunity
+
+Compile the route tree once when the router is created. Reuse the compiled branch list for all later matching.
+
+The likely shape is:
+
+```rescript
+type compiledRoutes
+
+external compileRoutes: array<route> => compiledRoutes = "compileRoutes"
+
+external matchCompiledRoutes: (
+  compiledRoutes,
+  RelayRouter__History.location,
+) => option<array<routeMatch>> = "matchCompiledRoutes"
+```
+
+The JS side can preserve most of the vendored implementation, but split it into two phases:
+
+- `compileRoutes(routes)`:
+  - flatten routes once
+  - rank branches once
+  - precompute route metadata
+  - optionally precompile path regexes for route segments
+- `matchCompiledRoutes(compiledRoutes, location)`:
+  - decode pathname
+  - iterate ranked branches
+  - match against precomputed branch metadata
+
+### Implementation Steps
+
+1. Add `compileRoutes` and `matchCompiledRoutes` to `vendor/react-router.js`.
+2. Keep `matchRoutes` as a compatibility wrapper that calls `matchCompiledRoutes(compileRoutes(routes), location)`.
+3. Add ReScript bindings in `RelayRouter.res` or a dedicated internal bindings module.
+4. In `Router.make`, compile routes once:
+
+   ```rescript
+   let compiledRoutes = compileRoutes(routes)
+   let matchLocation = matchCompiledRoutes(compiledRoutes, ...)
+   ```
+
+5. Update initial matching, navigation matching, and `runOnEachRouteMatch` to use the compiled matcher.
+6. Add tests showing that old `matchRoutes` and new compiled matching return identical matches for:
+   - root route
+   - nested route
+   - dynamic param route
+   - regex path param route
+   - unmatched route
+   - trailing slash behavior
+7. Add a small performance test or benchmark script that demonstrates flatten/sort is no longer repeated.
+
+### Validation
+
+- Existing router tests pass.
+- A new route-matching parity test passes.
+- Synthetic benchmark shows navigation/preload matching no longer scales with route-tree flattening and sorting.
+- Vite build still tree-shakes the vendored helper as before.
+
+### Risks
+
+- The vendored React Router helper is modified, so parity tests matter.
+- Route objects contain closures for loading/preparing routes. The compiled structure must preserve route object identity so matched route behavior remains unchanged.
+- Precompiled regexes must preserve current decoding behavior.
+
+## 2. Centralize Manifest-Backed Asset Preloading
+
+### Current State
+
+The router has a preload abstraction:
+
+- `Component`
+- `Image`
+- `Style`
+
+Client-side preloading currently de-dupes asset identifiers, but only component assets actually do anything:
+
+- `packages/rescript-relay-router/src/RelayRouter__AssetPreloader.res`
+
+SSR preloading is implemented in the Express example:
+
+- `examples/express/src/EntryServer.res`
+
+The example:
+
+- emits `<script type="module" src="...">` for component chunks
+- recursively walks direct imports
+- emits CSS preload tags
+- treats all manifest assets as images, with a TODO noting this can be wrong
+- has a TODO for duplicate chunk loads
+
+The Vite manifest transform already creates a router-specific manifest:
+
+- `packages/rescript-relay-router/vite-plugins/RescriptRelayVitePlugin__ManifestTransform.res`
+- `packages/rescript-relay-router/src/RelayRouter__Manifest.res`
+
+### Opportunity
+
+Move the default manifest-aware preloading logic into the router package. Make examples consume that default instead of implementing their own.
+
+The router should provide two default preload implementations:
+
+- Client: de-duped `import()` for component chunks, DOM `<link>` insertion for CSS/images/modules when useful.
+- Server: de-duped HTML tag emission through `PreloadInsertingStream`.
+
+The core design should make asset preloading explicit and safe:
+
+- Component chunks should generally use `rel="modulepreload"` on the server, not an eager script execution tag, unless there is a deliberate reason to execute.
+- CSS should use `rel="stylesheet"` or `rel="preload" as="style"` with clear tradeoffs.
+- Images should use `rel="preload" as="image"` only when the asset type is known.
+- Unknown assets should either not be preloaded or should carry metadata from the manifest transform.
+
+### Implementation Steps
+
+1. Extend `RelayRouter__Manifest.file` with enough metadata to avoid guessing asset types.
+   - Option A: store assets as records with `url` and `kind`.
+   - Option B: split manifest fields into `images`, `fonts`, `assets`, etc.
+   - Option C: keep raw assets but infer from extension in one central helper.
+2. Add a shared `AssetPreloader` helper that can expand a component chunk into:
+   - the chunk itself
+   - recursive static imports
+   - associated CSS
+   - associated known assets
+3. Ensure recursion is cycle-safe and de-duped by URL.
+4. Add a server preloader constructor, for example:
+
+   ```rescript
+   let makeServerAssetPreloader: (
+     ~manifest: RelayRouter__Manifest.t,
+     ~emit: string => unit,
+   ) => RelayRouter__Types.preloadAssetFn
+   ```
+
+5. Add a client preloader constructor that optionally accepts the manifest:
+
+   ```rescript
+   let makeClientAssetPreloader: (
+     preparedAssetsMap,
+     ~manifest: option<RelayRouter__Manifest.t>=?,
+   ) => RelayRouter__Types.preloadAssetFn
+   ```
+
+6. Replace the custom SSR implementation in `examples/express/src/EntryServer.res` with the router-provided default.
+7. Preserve the current user extension point: callers can still pass a custom `preloadAsset`.
+8. Add tests for de-dupe and manifest expansion.
+
+### Validation
+
+- SSR output includes no duplicate preload tags for the same URL.
+- Component routes emit module preload tags for the exact chunks needed.
+- CSS needed by matched chunks is emitted.
+- Unknown asset types are not mislabeled as images.
+- Existing examples still hydrate.
+- Client-side `Image` and `Style` preloads are no longer no-ops.
+
+### Risks
+
+- Browser preload behavior is sensitive. `modulepreload`, `preload`, and actual script execution are not interchangeable.
+- Over-preloading can hurt performance. The implementation should respect priority and make aggressive behavior opt-in where possible.
+- Vite manifest shape can differ across versions and config options.
+
+## 3. Reuse Unchanged Prepared Matches With an Explicit Freshness Policy
+
+### Current State
+
+On navigation, all matched routes are prepared again:
+
+- `packages/rescript-relay-router/src/RelayRouter.res`
+- `packages/rescript-relay-router/src/RelayRouter__Internal__DeclarationsSupport.res`
+
+This is intentional. The current code comments explain that Relay invalidation/staleness requires rerunning `Query.load` so Relay can decide whether to refetch.
+
+The downside is that a child-only navigation can still rerun parent route preparation. In nested layouts, parent routes often hold expensive layout queries or broad fragments. Repreparing every matched route can increase network pressure and cause unnecessary disposable churn.
+
+### Opportunity
+
+Add a route-level policy that controls when an existing prepared entry can be reused for `Render`.
+
+Possible API directions:
+
+```rescript
+type prepareFreshness =
+  | Always
+  | WhenRouteKeyChanges
+  | Custom((~previous: preparedRoute, ~next: prepareProps) => bool)
+```
+
+or a simpler generated/default field:
+
+```rescript
+type route = {
+  ...
+  preparePolicy: preparePolicy,
+}
+```
+
+Defaulting this is the important design decision:
+
+- Keep current behavior as the default for backward compatibility.
+- Allow routes to opt into reuse when the app author knows the route prepare is stable.
+- Potentially generate a conservative policy for routes with no query/data preparation.
+
+### Implementation Steps
+
+1. Add a policy field to `RelayRouter__Types.route`.
+2. Update codegen to emit the default policy for each route.
+3. Extend `prepareRoute` in `DeclarationsSupport` to decide whether `Render` can reuse an existing prepared route.
+4. Ensure reused prepared entries clear any preload cleanup timeout when they become active.
+5. Ensure route unmount disposal behavior still runs exactly once.
+6. Add route renderer API support if the policy should be user-configurable in `makeRenderer`.
+7. Add tests:
+   - unchanged parent route is reused when opted in
+   - changed route key still prepares
+   - default behavior remains current behavior
+   - stale preload cleanup is canceled when reused for render
+
+### Validation
+
+- Parent route `prepare` call count drops on child-only navigations when opted in.
+- Relay invalidation behavior remains intact for routes using the default policy.
+- Query disposables are not disposed before render.
+- Existing app behavior does not change unless the route opts in.
+
+### Risks
+
+- Incorrect reuse can serve stale Relay preloaded query refs.
+- The policy needs clear docs. Users should understand when reuse is safe.
+- A custom policy can become an API surface that is hard to evolve.
+
+## 4. Split the Route Declaration Payload From Lazy Route Prepare Modules
+
+### Current State
+
+Route renderers are dynamically imported. However, `RouteDeclarations.make()` eagerly creates the complete runtime route object tree. The generated declarations include per-route closures for:
+
+- route renderer loading
+- `makePrepareProps`
+- `makeRouteKey`
+- `preloadCode`
+- `prepare`
+- children
+
+Relevant generator code:
+
+- `packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res`
+
+This keeps route renderers out of the initial bundle, but not necessarily all route metadata and typed prepare-prop code.
+
+### Opportunity
+
+Split the generated route output into:
+
+1. A small always-loaded match manifest:
+   - route path
+   - route name
+   - route chunk identifier
+   - children
+2. Lazy per-route modules:
+   - prepare prop decoding
+   - route key building
+   - route renderer import
+   - route-specific query param parsing if not needed globally
+
+The runtime matcher only needs the match manifest. The router only needs the lazy module for matched routes that are being preloaded or rendered.
+
+### Implementation Steps
+
+1. Define a smaller route matching type, separate from the executable `route` type.
+2. Update the matcher binding to operate on this smaller type if needed.
+3. Generate a manifest-only `RouteDeclarations.makeManifest()`.
+4. Generate per-route loader modules that can produce the executable route behavior when matched.
+5. Update `Router.make` to accept either:
+   - current eager route objects
+   - new compiled/lazy route manifest
+6. Start behind a new experimental API to avoid forcing migration.
+7. Verify Vite chunk output. The whole purpose is defeated if the lazy modules are still pulled into the entry chunk.
+
+### Validation
+
+- Initial client bundle shrinks for a large generated route tree.
+- Route matching still works without loading unmatched route prepare modules.
+- Preloading a link loads only the modules for the matched branch.
+- SSR still has enough manifest data to emit correct preload tags.
+
+### Risks
+
+- This is a larger architectural shift.
+- It may complicate type-safe generated route module access.
+- Dynamic import boundaries from generated code need careful Vite/Rollup testing.
+
+## 5. Verify and Improve Renderer Chunk Boundaries
+
+### Current State
+
+Generated route renderer imports look like:
+
+```rescript
+import(Root__Todos__Single_route_renderer.renderer)
+```
+
+Scaffolded route renderer files often call through the generated `Routes` barrel:
+
+```rescript
+let renderer = Routes.Root.Todos.Single.Route.makeRenderer(...)
+```
+
+The generated route declaration code already knows the concrete module names. The route renderer chunk may not need to import the full `Routes` module.
+
+### Opportunity
+
+Verify whether using `Routes.Root...` inside each route renderer pulls more generated code into route chunks than necessary. If it does, change scaffolding to import/call the concrete generated route module directly:
+
+```rescript
+let renderer = Route__Root__Todos__Single_route.makeRenderer(...)
+```
+
+This may produce cleaner and smaller async chunks.
+
+### Implementation Steps
+
+1. Build the client example with the current scaffold style.
+2. Inspect Vite output or use a bundle visualizer.
+3. Change one route renderer manually to call its concrete route module.
+4. Rebuild and compare chunk contents.
+5. If the result is better, update `scaffold-route-renderers` generation in `RescriptRelayRouterCli__Commands.res`.
+6. Consider whether existing generated examples should be updated.
+
+### Validation
+
+- Route renderer chunks include only the route module they need.
+- No user-facing route API breaks.
+- Existing hand-written renderers using `Routes` still work.
+
+### Risks
+
+- ReScript or Vite may already tree-shake this well enough, making the change unnecessary.
+- The `Routes` access path is more ergonomic. Direct module references are less discoverable.
+
+## 6. Centralize Location Subscriptions
+
+### Current State
+
+`RelayRouter.Utils.useLocation` creates a new history listener for every hook consumer:
+
+- `packages/rescript-relay-router/src/RelayRouter__Utils.res`
+
+Generated hooks use this helper:
+
+- `useIsRouteActive`
+- `usePathParams`
+- `useQueryParams`
+
+Navigation bars and sidebars often render many active route checks. This can create many subscriptions to the same history source and many independent state updates per navigation.
+
+### Opportunity
+
+Make the router expose one external-store style subscription for location. All location-consuming hooks should read from the same store.
+
+Good implementation options:
+
+- Store current location in router context and update it from the existing history listener in `Router.make`.
+- Expose `useLocation` via `React.useSyncExternalStore` if available in the ReScript React bindings.
+- Reuse the existing `router.subscribe` if the route entry location is enough.
+
+The key goal is one history listener per router instance, not one per hook.
+
+### Implementation Steps
+
+1. Extend router context with:
+   - `getLocation: unit => location`
+   - `subscribeToLocation: (location => unit) => unsubFn`
+2. In `Router.make`, update location subscribers from the existing history listener.
+3. Rewrite `RelayRouter__Utils.useLocation` to subscribe to the router location store.
+4. Ensure shallow navigation semantics are correct:
+   - shallow query param changes may skip route preparation
+   - location consumers should probably still see location changes
+5. Add tests or a small instrumented fixture that verifies multiple hooks only create one history listener.
+
+### Validation
+
+- `useLocation` updates on push, replace, and pop.
+- Generated hooks still update correctly.
+- Shallow query param updates update `useQueryParams`.
+- Route renderer updates still happen through the existing route-entry subscription.
+
+### Risks
+
+- Current router route-entry updates skip shallow navigations. Location subscribers must not accidentally inherit that behavior if query param hooks should update.
+- React transition behavior should be reviewed. Some location updates may want transition scheduling, others may not.
+
+## 7. Make Route Keys Collision-Safe
+
+### Current State
+
+Generated route keys concatenate route name, path param values, and query param values without unambiguous delimiters:
+
+- `packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res`
+
+This can alias different parameter sets. For example, `a="bc"` and `a="b", c="c"` style combinations can collapse if multiple fields are concatenated without separators and field names.
+
+It can also mishandle array query params because route key generation currently reads a single query param value for each query field.
+
+### Opportunity
+
+Generate stable, collision-safe route keys.
+
+Possible formats:
+
+- JSON array of `[fieldName, value]` pairs.
+- Length-prefixed segments.
+- URLSearchParams-like stable serialization with sorted keys and repeated array entries.
+
+Example:
+
+```rescript
+"Root__Todos__Single:" ++ JSON.stringifyAny([
+  ["path", "todoId", todoId],
+  ["query", "showMore", showMore],
+])->Option.getOr("")
+```
+
+This is a correctness fix first. It also improves performance predictability because prepared cache entries cannot be accidentally reused across distinct route states.
+
+### Implementation Steps
+
+1. Decide route key encoding.
+2. Update `getMakeRouteKeyFn`.
+3. Ensure path params and query params include field names.
+4. Ensure array query params include all values in order or sorted order, depending on desired semantics.
+5. Add tests for:
+   - adjacent string collisions
+   - missing vs empty values
+   - array values
+   - reordered query params if the router treats them as equivalent
+6. Consider whether this is a breaking change for any user-observable behavior. It should be internal, but prepared cache behavior can change.
+
+### Validation
+
+- Distinct route param sets produce distinct keys.
+- Equivalent query string ordering produces equivalent keys if that is the desired semantic.
+- Existing preloading cache still works.
+
+### Risks
+
+- JSON stringification adds minor overhead. It is probably acceptable for correctness, but a length-prefixed string can be faster.
+- If current accidental collisions masked bugs, this can expose them.
+
+## 8. Support Rendering One Named Root-Level Route Tree
+
+### Use Case
+
+Some applications have multiple top-level route trees in one route definition file:
+
+```json
+[
+  {
+    "path": "/",
+    "name": "Root",
+    "children": []
+  },
+  {
+    "path": "/admin",
+    "name": "Admin",
+    "children": []
+  },
+  {
+    "path": "/embedded",
+    "name": "Embedded",
+    "children": []
+  }
+]
+```
+
+The desired behavior is to load and render only one of those root-level trees in a particular surface. For example:
+
+- The main app shell renders only `Root`.
+- An admin entrypoint renders only `Admin`.
+- An embedded widget or iframe renders only `Embedded`.
+- A host page may mount a separate route renderer for one named tree without pulling in the others.
+
+This is related to code splitting, but it is a distinct requirement. The goal is not only to code split route renderers after matching. The goal is to make the top-level route tree itself a selectable render and build boundary.
+
+### Current State
+
+The parser reads `routes.json` as an array of top-level routes:
+
+- `packages/rescript-relay-router/cli/RescriptRelayRouterCli__Parser.res`
+- `packages/rescript-relay-router/cli/RescriptRelayRouterCli__Types.res`
+
+The generated `RouteDeclarations.make()` returns all top-level route trees as one `array<RelayRouter.Types.route>`.
+
+`RelayRouter.RouteRenderer` renders the current router entry's full matched branch:
+
+- `packages/rescript-relay-router/src/RelayRouter.res`
+
+That works well for a single app-wide router. It does not give an ergonomic way to say "construct, match, preload, and render only the `Admin` top-level tree".
+
+### Opportunity
+
+Introduce named root route trees as a first-class generated concept.
+
+At minimum, codegen should expose each top-level route tree independently. Possible API shapes:
+
+```rescript
+let routes = RouteDeclarations.makeRoot(~root=#Admin)
+```
+
+or:
+
+```rescript
+let routes = RouteDeclarations.Admin.make()
+```
+
+or:
+
+```rescript
+let routes = RouteDeclarations.make(~roots=[#Admin])
+```
+
+The route name should likely come from the existing top-level `name` field. A top-level route named `Admin` becomes a selectable root tree named `#Admin`.
+
+This unlocks several patterns:
+
+- Create separate router contexts per entrypoint, each with only the relevant root tree.
+- Build separate client bundles that import only the relevant generated root-tree maker.
+- Keep type-safe route helpers for all routes available when desired, while allowing runtime declarations to be scoped.
+- Combine with lazy route declaration splitting later so importing `Admin.make()` does not pull `Root` and `Embedded` runtime declarations into the same bundle.
+
+### API Design Considerations
+
+There are two related but separate APIs:
+
+1. Route declaration construction.
+2. Route rendering from an existing router context.
+
+For route declaration construction, prefer a generated module per top-level route:
+
+```rescript
+let routes = RouteDeclarations.Admin.make()
+```
+
+This is friendlier to bundlers than a single `make(~root=#Admin)` switch because static imports can point at one generated module. It also leaves room for each top-level tree to live in its own generated file later.
+
+For route rendering, prefer keeping `RouteRenderer` simple and context-driven:
+
+```rescript
+let (_, routerContext) = RelayRouter.Router.make(
+  ~routes=RouteDeclarations.Admin.make(),
+  ...
+)
+
+<RelayRouter.Provider value=routerContext>
+  <RelayRouter.RouteRenderer />
+</RelayRouter.Provider>
+```
+
+An optional `RouteRenderer(~root=...)` prop is possible, but it is less clean because matching and preloading would still have happened against the broader route tree. Filtering at render time would save less work and could create confusing behavior where links preload routes the renderer will not show.
+
+### Implementation Steps
+
+1. Identify top-level route entries during codegen.
+2. Generate a module for each top-level route tree:
+
+   ```rescript
+   module Root = {
+     let make = (~prepareDisposeTimeout=?) => [rootRoute]
+   }
+
+   module Admin = {
+     let make = (~prepareDisposeTimeout=?) => [adminRoute]
+   }
+
+   module Embedded = {
+     let make = (~prepareDisposeTimeout=?) => [embeddedRoute]
+   }
+   ```
+
+3. Keep the current `RouteDeclarations.make()` API as the backwards-compatible "all roots" entrypoint.
+4. Ensure generated top-level modules share the same loaded route renderer cache only when that is desired.
+   - If multiple router contexts can exist on one page, a shared cache may be beneficial for code imports.
+   - Prepared route caches should remain scoped per `make()` result/router instance.
+5. Add generated signatures in `RouteDeclarations.resi`.
+6. Update README examples to show:
+   - all routes
+   - one named root tree
+   - separate app entrypoints using separate generated root modules
+7. Add codegen tests that verify generated modules exist for multiple top-level route entries.
+8. Add runtime tests or example coverage for creating a router with only one named root tree.
+
+### Code Splitting Follow-Up
+
+The first implementation can still generate all root-tree modules into one `RouteDeclarations.res` file. That gives the ergonomic API and runtime scoping, but it may not fully isolate bundle output.
+
+For stronger bundle isolation, follow up by generating one declaration file per top-level route tree:
+
+```text
+RouteDeclarations.res
+RouteDeclarations__Root.res
+RouteDeclarations__Admin.res
+RouteDeclarations__Embedded.res
+```
+
+Then `RouteDeclarations.Admin.make()` can be a small forwarding module, or app entrypoints can import `RouteDeclarations__Admin` directly. This should be validated with Vite output before committing to the split.
+
+### Interaction With Links and Preloading
+
+When a router is created with only one root tree:
+
+- `router.preload` should only match that root tree.
+- `RelayRouter.Link` should only preload routes in that root tree.
+- Navigating to a URL outside that root tree should produce no matches.
+- Type-safe `makeLink` helpers can still generate links to routes outside the current root tree if they are imported directly. That is acceptable, but docs should explain that a scoped router will not render unmatched trees.
+
+This behavior is preferable to render-time filtering because it scopes matching, preloading, preparation, and rendering consistently.
+
+### Validation
+
+- `RouteDeclarations.make()` preserves current behavior and returns all top-level route trees.
+- `RouteDeclarations.Admin.make()` returns only the `Admin` top-level route tree.
+- Matching `/admin/...` works in an admin-scoped router.
+- Matching `/embedded/...` does not work in an admin-scoped router.
+- Link preloading in an admin-scoped router does not prepare root or embedded routes.
+- A client entrypoint importing only the admin route declaration can be verified for bundle isolation if per-root generated files are implemented.
+
+### Risks
+
+- Top-level route names must be unique. They likely already are through full route names, but codegen should produce a clear diagnostic if a selectable root name would collide.
+- If multiple root trees intentionally share paths, root scoping changes which one can match. That is the point of the feature, but it should be documented.
+- Generating per-root files can complicate the current generated module structure and LSP helpers.
+- If top-level modules share `loadedRouteRenderers`, code loading can be shared across contexts. If they do not, duplicate dynamic import state may be tracked. Decide explicitly.
+
+## 9. Pool Link Intersection Observers
+
+### Current State
+
+Each `RelayRouter.Link` with `OnInView` creates its own `IntersectionObserver`:
+
+- `packages/rescript-relay-router/src/RelayRouter__Link.res`
+
+This is simple and works, but pages with many links can create many observers with identical options.
+
+The current observer uses:
+
+```rescript
+threshold: 1.
+```
+
+That means the link must be fully visible before in-view preloading fires.
+
+### Opportunity
+
+Use a shared observer per root/options combination. Track callbacks per element.
+
+Also consider changing the default visibility semantics:
+
+- `threshold: 0.` or a small threshold starts preloading earlier.
+- `rootMargin: "200px"` starts loading before the link enters the viewport.
+
+The default should be conservative, but the current threshold may be too late to help for many scrolling interactions.
+
+### Implementation Steps
+
+1. Add root margin support to the `IntersectionObserver` binding if needed.
+2. Create an internal observer registry keyed by:
+   - root element identity
+   - threshold
+   - root margin
+3. Register each link element with a callback.
+4. Unregister on effect cleanup.
+5. Disconnect the shared observer when no elements remain for that observer key.
+6. Add tests where possible, or a browser fixture if DOM observer behavior is hard to unit test.
+
+### Validation
+
+- Many links create one observer for shared options.
+- Preload fires once per link.
+- Cleanup removes callbacks and does not leak DOM nodes.
+- Custom scroll root behavior still works.
+
+### Risks
+
+- Root element identity is awkward as a dictionary key. A JS helper may be cleaner than doing all registry logic in ReScript.
+- Early preloading can increase network usage. Defaults should be measured.
+
+## 10. Replace Reflective Disposable Extraction
+
+### Current State
+
+Prepared route results are recursively scanned for objects with a `dispose` function:
+
+- `packages/rescript-relay-router/src/RelayRouter__Internal.res`
+
+This lets route prepare functions return Relay preloaded query refs without explicit disposal wiring. It is ergonomic but implicit and potentially expensive for complex prepared objects.
+
+It also means any object with a `dispose` function can be treated as a resource by convention.
+
+### Opportunity
+
+Introduce an explicit disposal API while preserving the current reflective fallback for compatibility.
+
+Possible renderer API:
+
+```rescript
+type preparedResult<'prepared> = {
+  prepared: 'prepared,
+  disposables: array<unit => unit>,
+}
+```
+
+or:
+
+```rescript
+makeRenderer(
+  ~prepare,
+  ~disposePrepared=?,
+  ~render,
+)
+```
+
+The second option avoids wrapping existing prepare returns but still gives explicit control.
+
+### Implementation Steps
+
+1. Extend internal renderer type with optional disposal hook.
+2. Update generated `makeRenderer` binding to accept it.
+3. In `prepareRoute`, prefer explicit disposables if supplied.
+4. Keep `extractDisposables` as fallback.
+5. Add tests:
+   - explicit disposal runs on unmount
+   - reflective fallback still works
+   - old disposables are delayed until new query refs can be used by React
+6. Document the recommended API for complex prepared values.
+
+### Validation
+
+- Existing route renderers keep working.
+- New explicit disposal path avoids recursive object walking.
+- Relay preloaded query refs are still disposed correctly.
+
+### Risks
+
+- The API may become noisier for users.
+- Having both explicit and reflective behavior can be confusing. Docs should state precedence clearly.
+
+## 11. Reduce Repeated Query Decoding
+
+### Current State
+
+Query params are parsed and decoded in several places:
+
+- During route preparation.
+- In generated route `useQueryParams` hooks.
+- In link-preservation helpers.
+- In route key generation.
+
+Generated code decodes each query param independently. Array params sometimes use memo dependencies based on joined strings.
+
+### Opportunity
+
+Cache parsed query params and route-specific decoded query records per location/search string.
+
+Possible design:
+
+- Router computes `QueryParams.t` once per navigation.
+- Router exposes the parsed `QueryParams.t` on current route entry or a query-param store.
+- Generated route modules expose a decoder identity/key.
+- Runtime memoizes decoded query records by `(search, routeName)` or `(search, decoderId)`.
+
+The simpler near-term improvement is to reuse parsed `QueryParams.t` across route preparation and route hooks where the same search string is already available.
+
+### Implementation Steps
+
+1. Audit every `QueryParams.parse` call.
+2. Add a small query parse cache keyed by raw `search`.
+3. Use it in:
+   - `Router.make`
+   - `runOnEachRouteMatch`
+   - `useSetQueryParams`
+   - `useMakeLinkWithPreservedPath`
+   - generated `useQueryParams`, if practical
+4. Consider generated decoder caching as a second phase.
+5. Add tests for query param updates and shallow navigation.
+
+### Validation
+
+- Query hooks still update on every search change.
+- Repeated parsing drops in an instrumented test.
+- Query array behavior remains unchanged.
+- Default-value serialization still works.
+
+### Risks
+
+- `URLSearchParams` is mutable. If cached, callers must not mutate shared instances unexpectedly.
+- The cache may need to return fresh copies for mutation-heavy call sites.
+- Over-caching can introduce subtle stale-state bugs.
+
+## 12. SSR Stream Logging and Cleanup
+
+### Current State
+
+`RelaySSRUtils` logs a lot of debug information directly:
+
+- `packages/rescript-relay-router/src/RelaySSRUtils.res`
+
+This includes streamed entry events, boot events, and replay subject cleanup. It is not the largest performance issue, but it can add noise and overhead in production SSR/hydration flows.
+
+### Opportunity
+
+Gate debug logs behind a configuration flag or remove them from the default path.
+
+This belongs in the same family as SSR asset preloading because both affect response streaming and hydration behavior.
+
+### Implementation Steps
+
+1. Add a debug flag or logging callback.
+2. Default it to disabled.
+3. Replace direct `Console.log` calls with the gated logger.
+4. Add a test or example check that production usage does not log by default.
+
+### Validation
+
+- No debug logs in normal example app boot.
+- Logs can still be enabled for stream debugging.
+
+### Risks
+
+- Debugging SSR streaming is hard. Keep an easy way to re-enable logs.
+
+## Suggested Work Slicing
+
+These work items can be picked up independently:
+
+1. Route-key safety:
+   - smallest codegen-only correctness fix
+   - good first issue before deeper cache work
+2. Compiled route matching:
+   - contained runtime/vendor change
+   - requires parity tests
+3. Server/client asset preloader:
+   - practical SSR and code-splitting payoff
+   - likely needs manifest type changes
+4. Location subscription store:
+   - contained React runtime change
+   - needs care around shallow navigation
+5. Named root-tree rendering:
+   - codegen and runtime scoping change
+   - useful for multi-entry apps, admin surfaces, and embedded route renderers
+6. Link observer pooling:
+   - contained link component change
+   - needs browser behavior validation
+7. Explicit disposal API:
+   - API evolution
+   - should preserve fallback behavior
+8. Prepare freshness policy:
+   - highest semantic risk
+   - should start behind opt-in policy
+9. Lazy route declaration split:
+   - larger architecture project
+   - should start with bundle analysis and a PoC
+10. Renderer chunk boundary verification:
+   - measurement-first
+   - may become a small scaffold generation change
+11. Query decoding cache:
+   - useful after route-key and location-store work clarify ownership of `search`
+
+## Recommended Starting Order
+
+Start with:
+
+1. Route-key safety.
+2. Compiled route matching.
+3. Centralized asset preloading.
+4. Named root-tree rendering, if multi-entry apps or embedded surfaces are a near-term target.
+5. Centralized location subscriptions.
+
+That order fixes one correctness issue, removes one clear hot-path inefficiency, improves SSR/code-splitting behavior, and adds a concrete route-tree boundary for multi-entry rendering before tackling lower-level React subscription churn. It also avoids changing Relay freshness semantics until there is enough measurement infrastructure to evaluate that tradeoff properly.

--- a/packages/rescript-relay-router/src/RelayRouter.res
+++ b/packages/rescript-relay-router/src/RelayRouter.res
@@ -15,9 +15,16 @@ module Utils = RelayRouter__Utils
 open Types
 open Bindings
 
+type compiledRoutes
+
+@module("./vendor/react-router.js")
+external compileRoutes: array<route> => compiledRoutes = "compileRoutes"
+
 @module("./vendor/react-router.js") @return(nullable)
-external matchRoutes: (array<route>, RelayRouter__History.location) => option<array<routeMatch>> =
-  "matchRoutes"
+external matchCompiledRoutes: (
+  compiledRoutes,
+  RelayRouter__History.location,
+) => option<array<routeMatch>> = "matchCompiledRoutes"
 
 let prepareMatches = (
   matches: array<routeMatch>,
@@ -65,7 +72,8 @@ module Router = {
       routerEventListeners.contents->Array.forEach(cb => cb(event))
     }
 
-    let matchLocation = matchRoutes(routes, ...)
+    let compiledRoutes = compileRoutes(routes)
+    let matchLocation = matchCompiledRoutes(compiledRoutes, ...)
     let location = RelayRouter__History.getLocation(history)
     let initialQueryParams = QueryParams.parse(location.search)
     let initialMatches = matchLocation(location)->Option.getOr([])

--- a/packages/rescript-relay-router/src/vendor/react-router.js
+++ b/packages/rescript-relay-router/src/vendor/react-router.js
@@ -19,18 +19,26 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
  * @see https://reactrouter.com/utils/match-routes
  */
 export function matchRoutes(routes, locationArg, basename = "/") {
+  return matchCompiledRoutes(compileRoutes(routes), locationArg, basename);
+}
+
+export function compileRoutes(routes) {
+  let branches = flattenRoutes(routes);
+  rankRouteBranches(branches);
+  return branches.map(compileRouteBranch);
+}
+
+export function matchCompiledRoutes(compiledRoutes, locationArg, basename = "/") {
   let location =
     typeof locationArg === "string" ? parsePath(locationArg) : locationArg;
   let pathname = stripBasename(location.pathname || "/", basename);
   if (pathname == null) {
     return null;
   }
-  let branches = flattenRoutes(routes);
-  rankRouteBranches(branches);
   let matches = null;
-  for (let i = 0; matches == null && i < branches.length; ++i) {
+  for (let i = 0; matches == null && i < compiledRoutes.length; ++i) {
     matches = matchRouteBranch(
-      branches[i],
+      compiledRoutes[i],
       // Incoming pathnames are generally encoded from either window.location
       // or from router.navigate, but we want to match against the unencoded
       // paths in the route definitions.  Memory router locations won't be
@@ -41,6 +49,19 @@ export function matchRoutes(routes, locationArg, basename = "/") {
     );
   }
   return matches;
+}
+function compileRouteBranch(branch) {
+  return {
+    ...branch,
+    routesMeta: branch.routesMeta.map((meta, index) => {
+      let end = index === branch.routesMeta.length - 1;
+      return {
+        ...meta,
+        end,
+        compiledPath: compilePath(meta.relativePath, meta.caseSensitive, end),
+      };
+    }),
+  };
 }
 function flattenRoutes(
   routes,
@@ -162,10 +183,7 @@ function matchRouteBranch(branch, pathname) {
       matchedPathname === "/"
         ? pathname
         : pathname.slice(matchedPathname.length) || "/";
-    let match = matchPath(
-      { path: meta.relativePath, caseSensitive: meta.caseSensitive, end },
-      remainingPathname
-    );
+    let match = matchCompiledPath(meta, remainingPathname);
     if (!match) return null;
     Object.assign(matchedParams, match.params);
     let route = meta.route;
@@ -183,6 +201,39 @@ function matchRouteBranch(branch, pathname) {
     }
   }
   return matches;
+}
+function matchCompiledPath(compiledMeta, pathname) {
+  let [matcher, paramNames] = compiledMeta.compiledPath;
+  let match = pathname.match(matcher);
+  if (!match) return null;
+  let matchedPathname = match[0];
+  let pathnameBase = matchedPathname.replace(/(.)\/+$/, "$1");
+  let captureGroups = match.slice(1);
+  let params = paramNames.reduce((memo, paramName, index) => {
+    // We need to compute the pathnameBase here using the raw splat value
+    // instead of using params["*"] later because it will be decoded then
+    if (paramName === "*") {
+      let splatValue = captureGroups[index] || "";
+      pathnameBase = matchedPathname
+        .slice(0, matchedPathname.length - splatValue.length)
+        .replace(/(.)\/+$/, "$1");
+    }
+    memo[paramName] = safelyDecodeURIComponent(
+      captureGroups[index] || "",
+      paramName
+    );
+    return memo;
+  }, {});
+  return {
+    params,
+    pathname: matchedPathname,
+    pathnameBase,
+    pattern: {
+      path: compiledMeta.relativePath,
+      caseSensitive: compiledMeta.caseSensitive,
+      end: compiledMeta.end,
+    },
+  };
 }
 /**
  * Returns a path with params interpolated.
@@ -220,37 +271,15 @@ export function matchPath(pattern, pathname) {
   if (typeof pattern === "string") {
     pattern = { path: pattern, caseSensitive: false, end: true };
   }
-  let [matcher, paramNames] = compilePath(
-    pattern.path,
-    pattern.caseSensitive,
-    pattern.end
+  return matchCompiledPath(
+    {
+      relativePath: pattern.path,
+      caseSensitive: pattern.caseSensitive,
+      end: pattern.end,
+      compiledPath: compilePath(pattern.path, pattern.caseSensitive, pattern.end),
+    },
+    pathname
   );
-  let match = pathname.match(matcher);
-  if (!match) return null;
-  let matchedPathname = match[0];
-  let pathnameBase = matchedPathname.replace(/(.)\/+$/, "$1");
-  let captureGroups = match.slice(1);
-  let params = paramNames.reduce((memo, paramName, index) => {
-    // We need to compute the pathnameBase here using the raw splat value
-    // instead of using params["*"] later because it will be decoded then
-    if (paramName === "*") {
-      let splatValue = captureGroups[index] || "";
-      pathnameBase = matchedPathname
-        .slice(0, matchedPathname.length - splatValue.length)
-        .replace(/(.)\/+$/, "$1");
-    }
-    memo[paramName] = safelyDecodeURIComponent(
-      captureGroups[index] || "",
-      paramName
-    );
-    return memo;
-  }, {});
-  return {
-    params,
-    pathname: matchedPathname,
-    pathnameBase,
-    pattern,
-  };
 }
 function compilePath(path, caseSensitive = false, end = true) {
   warning(

--- a/packages/rescript-relay-router/src/vendor/react-router.js
+++ b/packages/rescript-relay-router/src/vendor/react-router.js
@@ -178,7 +178,6 @@ function matchRouteBranch(branch, pathname) {
   let matches = [];
   for (let i = 0; i < routesMeta.length; ++i) {
     let meta = routesMeta[i];
-    let end = i === routesMeta.length - 1;
     let remainingPathname =
       matchedPathname === "/"
         ? pathname
@@ -202,7 +201,15 @@ function matchRouteBranch(branch, pathname) {
   }
   return matches;
 }
-function matchCompiledPath(compiledMeta, pathname) {
+function matchCompiledPath(
+  compiledMeta,
+  pathname,
+  pattern = {
+    path: compiledMeta.relativePath,
+    caseSensitive: compiledMeta.caseSensitive,
+    end: compiledMeta.end,
+  }
+) {
   let [matcher, paramNames] = compiledMeta.compiledPath;
   let match = pathname.match(matcher);
   if (!match) return null;
@@ -228,11 +235,7 @@ function matchCompiledPath(compiledMeta, pathname) {
     params,
     pathname: matchedPathname,
     pathnameBase,
-    pattern: {
-      path: compiledMeta.relativePath,
-      caseSensitive: compiledMeta.caseSensitive,
-      end: compiledMeta.end,
-    },
+    pattern,
   };
 }
 /**
@@ -271,15 +274,13 @@ export function matchPath(pattern, pathname) {
   if (typeof pattern === "string") {
     pattern = { path: pattern, caseSensitive: false, end: true };
   }
-  return matchCompiledPath(
-    {
-      relativePath: pattern.path,
-      caseSensitive: pattern.caseSensitive,
-      end: pattern.end,
-      compiledPath: compilePath(pattern.path, pattern.caseSensitive, pattern.end),
-    },
-    pathname
-  );
+  let compiledPattern = {
+    relativePath: pattern.path,
+    caseSensitive: pattern.caseSensitive,
+    end: pattern.end,
+    compiledPath: compilePath(pattern.path, pattern.caseSensitive, pattern.end),
+  };
+  return matchCompiledPath(compiledPattern, pathname, pattern);
 }
 function compilePath(path, caseSensitive = false, end = true) {
   warning(

--- a/packages/rescript-relay-router/test/CompiledRouteMatching.test.mjs
+++ b/packages/rescript-relay-router/test/CompiledRouteMatching.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   compileRoutes,
   matchCompiledRoutes,
+  matchPath,
   matchRoutes,
 } from "../src/vendor/react-router.js";
 
@@ -179,6 +180,13 @@ describe("compiled route matching", () => {
     expect(
       serializeMatches(matchCompiledRoutes(compiledRoutes, makeLocation("/teams/core")))
     ).toEqual(serializeMatches(matchRoutes(routes, makeLocation("/teams/core"))));
+  });
+
+  test("keeps matchPath result pattern identity", () => {
+    const pattern = { path: "/teams/:teamId" };
+    const match = matchPath(pattern, "/teams/core");
+
+    expect(match?.pattern).toBe(pattern);
   });
 
   test("preserves matched route object identity", () => {

--- a/packages/rescript-relay-router/test/CompiledRouteMatching.test.mjs
+++ b/packages/rescript-relay-router/test/CompiledRouteMatching.test.mjs
@@ -1,0 +1,219 @@
+import { describe, expect, test } from "vitest";
+import {
+  compileRoutes,
+  matchCompiledRoutes,
+  matchRoutes,
+} from "../src/vendor/react-router.js";
+
+const makeLocation = (pathname) => ({
+  pathname,
+  search: "",
+  hash: "",
+  state: null,
+  key: "test",
+});
+
+describe("compiled route matching", () => {
+  const routes = [
+    {
+      id: "root",
+      path: "/",
+      children: [
+        { id: "teams", path: "teams" },
+        { id: "team", path: "teams/:teamId" },
+        {
+          id: "member",
+          path: "teams/:teamId/members/:memberStatus(active|inactive)",
+        },
+        { id: "files", path: "files/*" },
+      ],
+    },
+    { id: "settings", path: "/settings" },
+  ];
+
+  const serializeMatches = (matches) =>
+    matches?.map((match) => ({
+      id: match.route.id,
+      params: { ...match.params },
+      pathname: match.pathname,
+      pathnameBase: match.pathnameBase,
+    })) ?? null;
+
+  test("reproduces repeated route-tree walking in the matchRoutes compatibility path", () => {
+    let childrenReads = 0;
+    const leafRoutes = [
+      { path: "teams/:teamId" },
+      { path: "teams/:teamId/members/:memberId(active|inactive)" },
+      { path: "files/*" },
+    ];
+    const routes = [
+      {
+        path: "/",
+        get children() {
+          childrenReads += 1;
+          return leafRoutes;
+        },
+      },
+    ];
+
+    expect(matchRoutes(routes, makeLocation("/teams/core"))).toHaveLength(2);
+    const readsAfterFirstMatch = childrenReads;
+
+    expect(matchRoutes(routes, makeLocation("/teams/core/members/active"))).toHaveLength(2);
+    expect(matchRoutes(routes, makeLocation("/files/a/b/c"))).toHaveLength(2);
+
+    expect(childrenReads).toBeGreaterThan(readsAfterFirstMatch);
+  });
+
+  test.each([
+    [
+      "/",
+      "root route",
+      [{ id: "root", params: {}, pathname: "/", pathnameBase: "/" }],
+    ],
+    [
+      "/teams",
+      "nested static route",
+      [
+        { id: "root", params: {}, pathname: "/", pathnameBase: "/" },
+        { id: "teams", params: {}, pathname: "/teams", pathnameBase: "/teams" },
+      ],
+    ],
+    [
+      "/teams/core",
+      "dynamic param route",
+      [
+        {
+          id: "root",
+          params: { teamId: "core" },
+          pathname: "/",
+          pathnameBase: "/",
+        },
+        {
+          id: "team",
+          params: { teamId: "core" },
+          pathname: "/teams/core",
+          pathnameBase: "/teams/core",
+        },
+      ],
+    ],
+    [
+      "/teams/core/members/active",
+      "regex path param route",
+      [
+        {
+          id: "root",
+          params: { teamId: "core", memberStatus: "active" },
+          pathname: "/",
+          pathnameBase: "/",
+        },
+        {
+          id: "member",
+          params: { teamId: "core", memberStatus: "active" },
+          pathname: "/teams/core/members/active",
+          pathnameBase: "/teams/core/members/active",
+        },
+      ],
+    ],
+    [
+      "/teams/core/members/inactive",
+      "second regex path param branch",
+      [
+        {
+          id: "root",
+          params: { teamId: "core", memberStatus: "inactive" },
+          pathname: "/",
+          pathnameBase: "/",
+        },
+        {
+          id: "member",
+          params: { teamId: "core", memberStatus: "inactive" },
+          pathname: "/teams/core/members/inactive",
+          pathnameBase: "/teams/core/members/inactive",
+        },
+      ],
+    ],
+    ["/teams/core/members/pending", "unmatched regex path param route", null],
+    [
+      "/files/a/b/c",
+      "splat route",
+      [
+        {
+          id: "root",
+          params: { "*": "a/b/c" },
+          pathname: "/",
+          pathnameBase: "/",
+        },
+        {
+          id: "files",
+          params: { "*": "a/b/c" },
+          pathname: "/files/a/b/c",
+          pathnameBase: "/files",
+        },
+      ],
+    ],
+    [
+      "/settings/",
+      "trailing slash",
+      [
+        {
+          id: "settings",
+          params: {},
+          pathname: "/settings/",
+          pathnameBase: "/settings",
+        },
+      ],
+    ],
+    ["/missing", "unmatched route", null],
+  ])("matches expected output for %s (%s)", (pathname, _, expected) => {
+    const compiledRoutes = compileRoutes(routes);
+
+    expect(
+      serializeMatches(matchCompiledRoutes(compiledRoutes, makeLocation(pathname)))
+    ).toEqual(expected);
+  });
+
+  test("keeps matchRoutes as a compatibility wrapper", () => {
+    const compiledRoutes = compileRoutes(routes);
+
+    expect(
+      serializeMatches(matchCompiledRoutes(compiledRoutes, makeLocation("/teams/core")))
+    ).toEqual(serializeMatches(matchRoutes(routes, makeLocation("/teams/core"))));
+  });
+
+  test("preserves matched route object identity", () => {
+    const compiledRoutes = compileRoutes(routes);
+    const matches = matchCompiledRoutes(compiledRoutes, makeLocation("/teams/core"));
+
+    expect(matches).toHaveLength(2);
+    expect(matches[0].route).toBe(routes[0]);
+    expect(matches[1].route).toBe(routes[0].children[1]);
+  });
+
+  test("compiled matching does not re-walk the route tree", () => {
+    let childrenReads = 0;
+    const leafRoutes = [
+      { path: "teams/:teamId" },
+      { path: "teams/:teamId/members/:memberId(active|inactive)" },
+      { path: "files/*" },
+    ];
+    const routes = [
+      {
+        path: "/",
+        get children() {
+          childrenReads += 1;
+          return leafRoutes;
+        },
+      },
+    ];
+
+    const compiledRoutes = compileRoutes(routes);
+    const readsAfterCompile = childrenReads;
+
+    expect(matchCompiledRoutes(compiledRoutes, makeLocation("/teams/core"))).toHaveLength(2);
+    expect(matchCompiledRoutes(compiledRoutes, makeLocation("/teams/core/members/active"))).toHaveLength(2);
+    expect(matchCompiledRoutes(compiledRoutes, makeLocation("/files/a/b/c"))).toHaveLength(2);
+
+    expect(childrenReads).toBe(readsAfterCompile);
+  });
+});

--- a/plans/2026-05-19-precompiled-route-matching.md
+++ b/plans/2026-05-19-precompiled-route-matching.md
@@ -1,0 +1,35 @@
+# Precompiled Route Matching
+
+## Decision
+
+Precompile route-tree matching metadata once when a router instance is created. Keep the existing
+`matchRoutes` helper as a compatibility wrapper, but have router runtime matching use
+`compileRoutes` plus `matchCompiledRoutes`.
+
+## Who
+
+zth-linzumi asked Codex to take `opt/precompile-route-matching` through to a merge-ready PR after
+the route slots and route declaration entrypoint work landed. Codex rebased the existing branch on
+latest `main` and kept the implementation focused on the route-matching hot path.
+
+## Why
+
+The route tree is static for a router instance, but the old matching path flattened and ranked the
+tree and compiled path regexes on every match. That cost is repeated for the initial location, each
+history update, and every route preload triggered by links. Precompiling moves stable work to router
+construction while preserving route object identity and existing match output.
+
+## Verification
+
+- Compiled matching tests cover parity with the compatibility `matchRoutes` path for root, nested,
+  dynamic param, regex param, splat, trailing slash, and unmatched routes.
+- Tests cover preserving matched route object identity.
+- Tests cover preserving `matchPath` result pattern identity for callers using the vendored helper
+  directly.
+- Tests cover that compiled matching does not re-walk route children after compilation.
+
+## Non-Goals
+
+- This does not change route config syntax or generated route declarations.
+- This does not add a benchmark harness beyond focused regression tests.
+- This does not change basename behavior.


### PR DESCRIPTION
## Summary

- Precompile route matching metadata once per router instance and reuse it for initial matching, navigation, and link preload matching.
- Keep `matchRoutes` as a compatibility wrapper around the compiled path.
- Add focused matcher tests for parity, route identity, `matchPath` compatibility, and avoiding repeated route-tree walking.
- Include the router optimization note, decision note, and patch changeset.

## Validation

- `yarn workspaces foreach run rescript format -all`
- `yarn build`
- `yarn test`
- `yarn install --immutable`
- `yarn changeset status --since origin/main`
- `git diff --check`
