### PR TITLE
[codex] Add separately renderable route roots

### DIFF
--- a/packages/rescript-relay-router/README.md
+++ b/packages/rescript-relay-router/README.md
@@ -149,6 +149,36 @@ Route names must:
 
 Any routes put in another route's `children` is _nested_. In the example above, this means that the `Organization` route controls rendering of all of its child routes. This enables nested layouts, where layouts can stay rendered and untouched as URL changes in ways that does not affect them.
 
+Top-level routes can opt into being created as standalone route declaration entrypoints by setting `separatelyRenderable` to `true`. This is useful for multi-entry apps, admin surfaces, or embedded route trees where a router should match, preload, prepare, and render only one top-level tree.
+
+```json
+[
+  {
+    "name": "Root",
+    "path": "/"
+  },
+  {
+    "name": "Admin",
+    "path": "/admin",
+    "separatelyRenderable": true,
+    "children": [{ "name": "Users", "path": "users" }]
+  }
+]
+```
+
+The default generated `RouteDeclarations.make()` still returns all top-level route trees. Marked roots also get a generated module:
+
+```rescript
+let (_, routerContext) = RelayRouter.Router.make(
+  ~routes=RouteDeclarations.Admin.make(),
+  ~environment=RelayEnv.environment,
+  ~routerEnvironment=RelayRouter.RouterEnvironment.makeBrowserEnvironment(),
+  ~preloadAsset=RelayRouter.AssetPreloader.makeClientAssetPreloader(preparedAssetsMap),
+)
+```
+
+`separatelyRenderable` is only valid on top-level routes. A router built with `RouteDeclarations.Admin.make()` will not match or preload sibling root trees.
+
 To create a "catch all" route, use the `*`, character as the route path. Typically used for the "not found" route. Example:
 
 ```json

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Commands.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Commands.res
@@ -137,6 +137,25 @@ let generateRoutes = (~scaffoldAfter, ~deleteRemoved, ~config) => {
   })
 
   // Write the full route declarations file
+  let separatelyRenderableRootModules =
+    routes
+    ->Array.filter(route => route.separatelyRenderable)
+    ->Array.map(route => {
+      let moduleName = route.name->Types.RouteName.getRouteName
+      `module ${moduleName} = {
+  let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> => {
+    let {prepareRoute, getPrepared} = makePrepareAssets(~loadedRouteRenderers, ~prepareDisposeTimeout)
+
+    [
+      ${Codegen.getRouteDefinition(route, ~indentation=3)}
+    ]
+  }
+}`
+    })
+    ->Array.join("\n\n")
+  let separatelyRenderableRootModulesSection =
+    separatelyRenderableRootModules === "" ? "" : separatelyRenderableRootModules ++ "\n\n"
+
   let fileContents = `
 open RelayRouter__Internal__DeclarationsSupport
 
@@ -144,7 +163,7 @@ external unsafe_toPrepareProps: 'any => prepareProps = "%identity"
 
 let loadedRouteRenderers: Map.t<string, loadedRouteRenderer> = Map.make()
 
-let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> => {
+${separatelyRenderableRootModulesSection}let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> => {
   let {prepareRoute, getPrepared} = makePrepareAssets(~loadedRouteRenderers, ~prepareDisposeTimeout)
 
   [
@@ -159,10 +178,25 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
   )
 
   // Write interface file as the signature of this will never change
+  let separatelyRenderableRootModuleSignatures =
+    routes
+    ->Array.filter(route => route.separatelyRenderable)
+    ->Array.map(route => {
+      let moduleName = route.name->Types.RouteName.getRouteName
+      `module ${moduleName}: {
+  let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>
+}`
+    })
+    ->Array.join("\n\n")
+  let separatelyRenderableRootModuleSignaturesSection =
+    separatelyRenderableRootModuleSignatures === ""
+      ? ""
+      : separatelyRenderableRootModuleSignatures ++ "\n\n"
+
   Utils.pathInGeneratedFolder(
     ~config,
     ~fileName="RouteDeclarations.resi",
-  )->Fs.writeFileIfChanged(`let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>`)
+  )->Fs.writeFileIfChanged(`${separatelyRenderableRootModuleSignaturesSection}let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>`)
 
   if scaffoldAfter {
     scaffoldRouteRenderers(~deleteRemoved, ~config)

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Parser.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Parser.res
@@ -668,6 +668,33 @@ module Validators = {
     | None => None
     }
   }
+
+  let validateSeparatelyRenderable = (
+    separatelyRenderableNode,
+    ~ctx,
+    ~parentContext: parentContext,
+  ) => {
+    switch separatelyRenderableNode {
+    | Some({loc, value: Boolean({value: true})}) =>
+      if parentContext.routeDepth === 0 {
+        true
+      } else {
+        ctx.addDecodeError(
+          ~loc,
+          ~message=`"separatelyRenderable" can only be used on top-level routes.`,
+        )
+        false
+      }
+    | Some({value: Boolean({value: false})}) => false
+    | Some({loc, value: node}) =>
+      ctx.addDecodeError(
+        ~loc,
+        ~message=`"separatelyRenderable" needs to be a boolean. Found ${nodeToString(node)}.`,
+      )
+      false
+    | None => false
+    }
+  }
 }
 
 module Decode = {
@@ -778,9 +805,14 @@ module Decode = {
         let pathProp = properties->findPropertyWithName(~name="path")
         let nameProp = properties->findPropertyWithName(~name="name")
         let children = properties->findPropertyWithName(~name="children")
+        let separatelyRenderableProp = properties->findPropertyWithName(~name="separatelyRenderable")
 
         let name = nameProp->Validators.validateName(~ctx, ~siblings)
         let path = pathProp->Validators.validatePath(~ctx, ~parentContext)
+        let separatelyRenderable = separatelyRenderableProp->Validators.validateSeparatelyRenderable(
+          ~ctx,
+          ~parentContext,
+        )
 
         // Params are inherited from all parent routes. This concatenates the
         // previously seen path params from the parents.
@@ -822,6 +854,7 @@ module Decode = {
               pathParams,
               routePath,
               queryParams: path.queryParams->Array.copy,
+              separatelyRenderable,
               children: None,
               sourceFile: ctx.routeFileName,
               parentRouteFiles: parentContext.traversedRouteFiles->List.toArray,
@@ -841,6 +874,7 @@ module Decode = {
               pathParams,
               queryParams: [],
               routePath: RoutePath.empty(),
+              separatelyRenderable,
               children: None,
               sourceFile: ctx.routeFileName,
               parentRouteFiles: parentContext.traversedRouteFiles->List.toArray,
@@ -872,6 +906,7 @@ module Decode = {
                   currentRoutePath: routePath,
                   currentRouteNamePath: thisRouteNamePath,
                   seenQueryParams: path.queryParams,
+                  routeDepth: parentContext.routeDepth + 1,
                   parentRouteLoc: Some({
                     childrenArray: loc,
                   }),
@@ -892,6 +927,7 @@ module Decode = {
               routePath,
               pathParams,
               queryParams: path.queryParams->Array.copy,
+              separatelyRenderable,
               children,
               sourceFile: ctx.routeFileName,
               parentRouteFiles: parentContext.traversedRouteFiles->List.toArray,
@@ -1091,6 +1127,7 @@ let emptyParentCtx = (~routesByName) => {
   seenPathParams: list{},
   traversedRouteFiles: list{},
   parentRouteLoc: None,
+  routeDepth: 0,
   routesByName,
 }
 

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Types.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Types.res
@@ -158,6 +158,7 @@ and routeEntry = {
   routePath: RoutePath.t,
   pathParams: array<pathParam>,
   queryParams: array<queryParamNode>,
+  separatelyRenderable: bool,
   children: option<array<routeChild>>,
   sourceFile: string,
   parentRouteFiles: array<string>,
@@ -204,6 +205,7 @@ type parentContext = {
   seenPathParams: list<seenPathParam>,
   traversedRouteFiles: list<string>,
   parentRouteLoc: option<parentRouteLoc>,
+  routeDepth: int,
   routesByName: dict<routeEntry>,
 }
 
@@ -224,6 +226,7 @@ type rec printableRoute = {
   name: RouteName.t,
   children: array<printableRoute>,
   queryParams: dict<queryParam>,
+  separatelyRenderable: bool,
   sourceFile: string,
 }
 

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Utils.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Utils.res
@@ -203,6 +203,7 @@ and parsedToPrintable = (routeEntry: routeEntry): printableRoute => {
   queryParams: routeEntry.queryParams
   ->Array.map(({name, queryParam: (_loc, queryParam)}) => (name.text, queryParam))
   ->Dict.fromArray,
+  separatelyRenderable: routeEntry.separatelyRenderable,
   sourceFile: routeEntry.sourceFile,
 }
 

--- a/packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res
+++ b/packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res
@@ -3,6 +3,16 @@ open RescriptRelayRouterCli__Types
 
 module U = RescriptRelayRouterCli__Utils
 module DumpRoutes = RescriptRelayRouterCli__DumpRoutes
+module Bindings = RescriptRelayRouterCli__Bindings
+
+@module("os") external tmpdir: unit => string = "tmpdir"
+@module("fs") external mkdtempSync: string => string = "mkdtempSync"
+@module("fs") external mkdirRecursiveSync: (string, @as(json`{"recursive":true}`) _) => unit = "mkdirSync"
+@module("fs") external writeFileSync: (string, string) => unit = "writeFileSync"
+@module("fs") external readFileSync: (string, @as(json`"utf-8"`) _) => string = "readFileSync"
+@module("fs") external rmSync: (string, @as(json`{"recursive":true,"force":true}`) _) => unit = "rmSync"
+@send external indexOfFrom: (string, string, int) => int = "indexOf"
+@send external slice: (string, int, int) => string = "slice"
 
 let stringifyDump = dumped =>
   dumped->Array.map(route => JSON.Object(route))->JSON.Array->JSON.stringify
@@ -11,6 +21,45 @@ let testConfig = {
   generatedPath: "src/routes/__generated__",
   routesFolderPath: "src/routes",
   rescriptLibFolderPath: "lib/bs",
+}
+
+let withGeneratedRoutes = (routesJson, callback) => {
+  let rootPath = mkdtempSync(Bindings.Path.join([tmpdir(), "rrr-routes-"]))
+  let routesFolderPath = Bindings.Path.join([rootPath, "routes"])
+  let generatedPath = Bindings.Path.join([rootPath, "__generated__"])
+
+  mkdirRecursiveSync(routesFolderPath)
+  mkdirRecursiveSync(generatedPath)
+  writeFileSync(Bindings.Path.join([routesFolderPath, "routes.json"]), routesJson)
+
+  try {
+    RescriptRelayRouterCli__Commands.generateRoutes(
+      ~scaffoldAfter=false,
+      ~deleteRemoved=false,
+      ~config={
+        generatedPath,
+        routesFolderPath,
+        rescriptLibFolderPath: Bindings.Path.join([rootPath, "lib", "bs"]),
+      },
+    )
+
+    let result = callback(~generatedPath)
+    rmSync(rootPath)
+    result
+  } catch {
+  | exn =>
+    rmSync(rootPath)
+    throw(exn)
+  }
+}
+
+let readGeneratedFile = (~generatedPath, ~fileName) =>
+  readFileSync(Bindings.Path.join([generatedPath, fileName]))
+
+let sliceBetween = (content, ~startMarker, ~endMarker) => {
+  let start = content->String.indexOf(startMarker)
+  let end_ = content->indexOfFrom(endMarker, start + startMarker->String.length)
+  content->slice(start, end_)
 }
 
 describe("Query params", () => {
@@ -104,6 +153,98 @@ describe("Query params", () => {
         ~variableName="propName",
       ),
     )->Expect.toBe("propName->Array.map(value => value->SomeModule.parse)")
+  })
+})
+
+describe("Route declarations", () => {
+  test("generates standalone make modules only for top-level routes marked separatelyRenderable", _t => {
+    withGeneratedRoutes(
+      `[
+        {
+          "name": "Root",
+          "path": "/",
+          "children": [
+            {
+              "name": "Dashboard",
+              "path": "dashboard"
+            }
+          ]
+        },
+        {
+          "name": "Admin",
+          "path": "/admin",
+          "separatelyRenderable": true,
+          "children": [
+            {
+              "name": "Users",
+              "path": "users"
+            }
+          ]
+        },
+        {
+          "name": "Embedded",
+          "path": "/embedded",
+          "separatelyRenderable": false
+        }
+      ]`,
+      (~generatedPath) => {
+        let routeDeclarations = readGeneratedFile(~generatedPath, ~fileName="RouteDeclarations.res")
+        let routeDeclarationsInterface = readGeneratedFile(
+          ~generatedPath,
+          ~fileName="RouteDeclarations.resi",
+        )
+
+        expect(routeDeclarations)->Expect.String.toContain("module Admin = {")
+        expect(routeDeclarations)->Expect.String.toContain(
+          "let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> =>",
+        )
+        let adminModule = routeDeclarations->sliceBetween(
+          ~startMarker="module Admin = {",
+          ~endMarker="\n\nlet make = (~prepareDisposeTimeout",
+        )
+        expect(adminModule)->Expect.String.toContain(`let routeName = "Admin"`)
+        expect(adminModule)->Expect.String.toContain(`let routeName = "Admin__Users"`)
+        expect(adminModule)->Expect.not->Expect.String.toContain(`let routeName = "Root"`)
+        expect(adminModule)->Expect.not->Expect.String.toContain(`let routeName = "Embedded"`)
+        expect(routeDeclarations)->Expect.String.toContain(
+          `let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> =>`,
+        )
+        expect(routeDeclarations)->Expect.not->Expect.String.toContain("module Root = {")
+        expect(routeDeclarations)->Expect.not->Expect.String.toContain("module Embedded = {")
+
+        expect(routeDeclarationsInterface)->Expect.String.toContain("module Admin: {")
+        expect(routeDeclarationsInterface)->Expect.String.toContain(
+          "let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>",
+        )
+        expect(routeDeclarationsInterface)->Expect.not->Expect.String.toContain("module Root:")
+        expect(routeDeclarationsInterface)->Expect.not->Expect.String.toContain("module Embedded:")
+      },
+    )
+  })
+
+  test("preserves the existing all-routes RouteDeclarations.make output", _t => {
+    withGeneratedRoutes(
+      `[
+        {
+          "name": "Root",
+          "path": "/"
+        },
+        {
+          "name": "Admin",
+          "path": "/admin",
+          "separatelyRenderable": true
+        }
+      ]`,
+      (~generatedPath) => {
+        let routeDeclarations = readGeneratedFile(~generatedPath, ~fileName="RouteDeclarations.res")
+
+        expect(routeDeclarations)->Expect.String.toContain(
+          `let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> =>`,
+        )
+        expect(routeDeclarations)->Expect.String.toContain(`let routeName = "Root"`)
+        expect(routeDeclarations)->Expect.String.toContain(`let routeName = "Admin"`)
+      },
+    )
   })
 })
 

--- a/packages/rescript-relay-router/test/RescriptRelayRouterCli__Parser_test.test.res
+++ b/packages/rescript-relay-router/test/RescriptRelayRouterCli__Parser_test.test.res
@@ -3,6 +3,16 @@ open RescriptRelayRouterTestUtils.Vitest
 module P = RescriptRelayRouterCli__Parser
 module Bindings = RescriptRelayRouterCli__Bindings
 
+let parseRouteStructure = mockContent =>
+  P.readRouteStructure(
+    ~config={
+      generatedPath: "",
+      routesFolderPath: "",
+      rescriptLibFolderPath: "",
+    },
+    ~getRouteFileContents=_ => Ok(mockContent),
+  )
+
 let makeMockParserCtx = (
   ~content,
   ~routeFileName="routes.json",
@@ -80,5 +90,56 @@ describe("Parsing", () => {
       )->Expect.toEqual(["memberId", "slug"])
     | _ => ()
     }
+  })
+
+  test("allows separatelyRenderable on top-level routes", _t => {
+    let {errors, result} = parseRouteStructure(`[
+      {
+        "name": "Admin",
+        "path": "/admin",
+        "separatelyRenderable": true
+      }
+    ]`)
+
+    suite->assertions(2)
+    expect(errors)->Expect.Array.toHaveLength(0)
+    switch result {
+    | [RouteEntry({separatelyRenderable})] => expect(separatelyRenderable)->Expect.toBe(true)
+    | _ => ()
+    }
+  })
+
+  test("reports separatelyRenderable on nested routes", _t => {
+    let {errors} = parseRouteStructure(`[
+      {
+        "name": "Root",
+        "path": "/",
+        "children": [
+          {
+            "name": "Settings",
+            "path": "settings",
+            "separatelyRenderable": true
+          }
+        ]
+      }
+    ]`)
+
+    expect(errors->Array.map(error => error.message))->Expect.Array.toContain(
+      `"separatelyRenderable" can only be used on top-level routes.`,
+    )
+  })
+
+  test("reports non-boolean separatelyRenderable values", _t => {
+    let {errors} = parseRouteStructure(`[
+      {
+        "name": "Admin",
+        "path": "/admin",
+        "separatelyRenderable": "true"
+      }
+    ]`)
+
+    expect(errors->Array.map(error => error.message))->Expect.Array.toContain(
+      `"separatelyRenderable" needs to be a boolean. Found string("true").`,
+    )
   })
 })


### PR DESCRIPTION
## Summary

Adds an explicit `separatelyRenderable` route-definition flag for top-level routes. Marked roots now get generated `RouteDeclarations.<Root>.make()` modules while the existing `RouteDeclarations.make()` all-routes API remains unchanged.

## Details

- Parses and propagates `separatelyRenderable` through route entry and printable route models.
- Validates that the flag is boolean and only used on top-level route entries.
- Generates scoped route declaration modules and `.resi` signatures only for opted-in roots.
- Documents the new route-definition flag and scoped router usage.
- Adds parser and codegen tests that first capture the missing behavior and then verify the generated scoped output.

## Validation

- `yarn workspace rescript-relay-router build`
- `yarn workspace rescript-relay-router test -- RescriptRelayRouterCli`
- `yarn test`
- `yarn build`