### PR TITLE
[codex] Add route declaration entrypoints

### DIFF
--- a/.changeset/route-declaration-entrypoints.md
+++ b/.changeset/route-declaration-entrypoints.md
@@ -1,0 +1,7 @@
+---
+"rescript-relay-router": minor
+---
+
+Add route declaration entrypoints for top-level route trees.
+
+Top-level routes can now set `entrypoint: true` in route config, which generates a standalone `RouteDeclarations.<RouteName>.make()` module for building a router from only that route tree.

--- a/packages/rescript-relay-router/README.md
+++ b/packages/rescript-relay-router/README.md
@@ -149,6 +149,36 @@ Route names must:
 
 Any routes put in another route's `children` is _nested_. In the example above, this means that the `Organization` route controls rendering of all of its child routes. This enables nested layouts, where layouts can stay rendered and untouched as URL changes in ways that does not affect them.
 
+Top-level routes can opt into being created as standalone route declaration entrypoints by setting `entrypoint` to `true`. This is useful for multi-entry apps, admin surfaces, or embedded route trees where a router should match, preload, prepare, and render only one top-level tree.
+
+```json
+[
+  {
+    "name": "Root",
+    "path": "/"
+  },
+  {
+    "name": "Admin",
+    "path": "/admin",
+    "entrypoint": true,
+    "children": [{ "name": "Users", "path": "users" }]
+  }
+]
+```
+
+The default generated `RouteDeclarations.make()` still returns all top-level route trees. Marked roots also get a generated module:
+
+```rescript
+let (_, routerContext) = RelayRouter.Router.make(
+  ~routes=RouteDeclarations.Admin.make(),
+  ~environment=RelayEnv.environment,
+  ~routerEnvironment=RelayRouter.RouterEnvironment.makeBrowserEnvironment(),
+  ~preloadAsset=RelayRouter.AssetPreloader.makeClientAssetPreloader(preparedAssetsMap),
+)
+```
+
+`entrypoint` is only valid on top-level routes. A router built with `RouteDeclarations.Admin.make()` will not match or preload sibling root trees.
+
 Routes can also declare named slots and let descendant routes render into those slots instead of the normal `childRoutes` chain. This is useful for route-owned overlays, drawers, inspectors, and other UI that should keep the surrounding shell mounted while the URL remains a normal route URL.
 
 ```json

--- a/packages/rescript-relay-router/README.md
+++ b/packages/rescript-relay-router/README.md
@@ -177,7 +177,7 @@ let (_, routerContext) = RelayRouter.Router.make(
 )
 ```
 
-`entrypoint` is only valid on top-level routes. A router built with `RouteDeclarations.Admin.make()` will not match or preload sibling root trees.
+`entrypoint` is only valid on top-level routes. A router built with `RouteDeclarations.Admin.make()` will not match or preload sibling root trees. Entrypoint routes cannot be named `RelayRouter`, because that generated module name would shadow the router runtime module in `RouteDeclarations`.
 
 Routes can also declare named slots and let descendant routes render into those slots instead of the normal `childRoutes` chain. This is useful for route-owned overlays, drawers, inspectors, and other UI that should keep the surrounding shell mounted while the URL remains a normal route URL.
 

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Commands.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Commands.res
@@ -137,13 +137,34 @@ let generateRoutes = (~scaffoldAfter, ~deleteRemoved, ~config) => {
   })
 
   // Write the full route declarations file
+  let entrypointRootModules =
+    routes
+    ->Array.filter(route => route.entrypoint)
+    ->Array.map(route => {
+      let moduleName = route.name->Types.RouteName.getRouteName
+      `module ${moduleName} = {
+  let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> => {
+    let {prepareRoute, getPrepared} = makePrepareAssets(~loadedRouteRenderers, ~prepareDisposeTimeout)
+
+    [
+      ${Codegen.getRouteDefinition(route, ~indentation=3)}
+    ]
+  }
+}`
+    })
+    ->Array.join("\n\n")
+  let entrypointRootModulesSection = switch entrypointRootModules {
+  | "" => ""
+  | entrypointRootModules => `${entrypointRootModules}\n\n`
+  }
+
   let fileContents = `open RelayRouter__Internal__DeclarationsSupport
 
 external unsafe_toPrepareProps: 'any => prepareProps = "%identity"
 
 let loadedRouteRenderers: Map.t<string, loadedRouteRenderer> = Map.make()
 
-let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> => {
+${entrypointRootModulesSection}let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> => {
   let {prepareRoute, getPrepared} = makePrepareAssets(~loadedRouteRenderers, ~prepareDisposeTimeout)
 
   [
@@ -158,10 +179,24 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
   )
 
   // Write interface file as the signature of this will never change
-  Utils.pathInGeneratedFolder(
-    ~config,
-    ~fileName="RouteDeclarations.resi",
-  )->Fs.writeFileIfChanged(`let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>`)
+  let entrypointRootModuleSignatures =
+    routes
+    ->Array.filter(route => route.entrypoint)
+    ->Array.map(route => {
+      let moduleName = route.name->Types.RouteName.getRouteName
+      `module ${moduleName}: {
+  let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>
+}`
+    })
+    ->Array.join("\n\n")
+  let entrypointRootModuleSignaturesSection = switch entrypointRootModuleSignatures {
+  | "" => ""
+  | entrypointRootModuleSignatures => `${entrypointRootModuleSignatures}\n\n`
+  }
+
+  Utils.pathInGeneratedFolder(~config, ~fileName="RouteDeclarations.resi")->Fs.writeFileIfChanged(
+    `${entrypointRootModuleSignaturesSection}let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>`,
+  )
 
   if scaffoldAfter {
     scaffoldRouteRenderers(~deleteRemoved, ~config)

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Parser.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Parser.res
@@ -682,6 +682,26 @@ module Validators = {
       None
     }
   }
+
+  let validateEntrypoint = (entrypointNode, ~ctx, ~parentContext: parentContext) => {
+    switch entrypointNode {
+    | Some({loc, value: Boolean({value: true})}) =>
+      switch parentContext.routeDepth === 0 {
+      | true => true
+      | false =>
+        ctx.addDecodeError(~loc, ~message=`"entrypoint" can only be used on top-level routes.`)
+        false
+      }
+    | Some({value: Boolean({value: false})}) => false
+    | Some({loc, value: node}) =>
+      ctx.addDecodeError(
+        ~loc,
+        ~message=`"entrypoint" needs to be a boolean. Found ${nodeToString(node)}.`,
+      )
+      false
+    | None => false
+    }
+  }
 }
 
 module Decode = {
@@ -874,11 +894,13 @@ module Decode = {
         let children = properties->findPropertyWithName(~name="children")
         let slotsProp = properties->findPropertyWithName(~name="slots")
         let outletProp = properties->findPropertyWithName(~name="outlet")
+        let entrypointProp = properties->findPropertyWithName(~name="entrypoint")
 
         let name = nameProp->Validators.validateName(~ctx, ~siblings)
         let path = pathProp->Validators.validatePath(~ctx, ~parentContext)
         let slots = slotsProp->validateSlots(~ctx)
         let outlet = outletProp->validateOutlet(~ctx, ~parentContext)
+        let entrypoint = entrypointProp->Validators.validateEntrypoint(~ctx, ~parentContext)
 
         // Params are inherited from all parent routes. This concatenates the
         // previously seen path params from the parents.
@@ -922,6 +944,7 @@ module Decode = {
               queryParams: path.queryParams->Array.copy,
               slots,
               outlet,
+              entrypoint,
               children: None,
               sourceFile: ctx.routeFileName,
               parentRouteFiles: parentContext.traversedRouteFiles->List.toArray,
@@ -943,6 +966,7 @@ module Decode = {
               routePath: RoutePath.empty(),
               slots,
               outlet,
+              entrypoint,
               children: None,
               sourceFile: ctx.routeFileName,
               parentRouteFiles: parentContext.traversedRouteFiles->List.toArray,
@@ -977,6 +1001,7 @@ module Decode = {
                   availableSlots: parentContext.availableSlots->Array.concat(
                     slots->Array.map(slot => slot.name.text),
                   ),
+                  routeDepth: parentContext.routeDepth + 1,
                   parentRouteLoc: Some({
                     childrenArray: loc,
                   }),
@@ -999,6 +1024,7 @@ module Decode = {
               queryParams: path.queryParams->Array.copy,
               slots,
               outlet,
+              entrypoint,
               children,
               sourceFile: ctx.routeFileName,
               parentRouteFiles: parentContext.traversedRouteFiles->List.toArray,
@@ -1199,6 +1225,7 @@ let emptyParentCtx = (~routesByName) => {
   traversedRouteFiles: list{},
   parentRouteLoc: None,
   availableSlots: [],
+  routeDepth: 0,
   routesByName,
 }
 

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Parser.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Parser.res
@@ -901,6 +901,14 @@ module Decode = {
         let slots = slotsProp->validateSlots(~ctx)
         let outlet = outletProp->validateOutlet(~ctx, ~parentContext)
         let entrypoint = entrypointProp->Validators.validateEntrypoint(~ctx, ~parentContext)
+        switch (entrypoint, name) {
+        | (true, Some({name: "RelayRouter", loc})) =>
+          ctx.addDecodeError(
+            ~loc,
+            ~message=`"RelayRouter" cannot be used as an entrypoint route name because it would shadow the router runtime module in generated route declarations.`,
+          )
+        | _ => ()
+        }
 
         // Params are inherited from all parent routes. This concatenates the
         // previously seen path params from the parents.

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Types.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Types.res
@@ -162,6 +162,7 @@ and routeEntry = {
   queryParams: array<queryParamNode>,
   slots: array<slotDef>,
   outlet: option<textNode>,
+  entrypoint: bool,
   children: option<array<routeChild>>,
   sourceFile: string,
   parentRouteFiles: array<string>,
@@ -209,6 +210,7 @@ type parentContext = {
   traversedRouteFiles: list<string>,
   parentRouteLoc: option<parentRouteLoc>,
   availableSlots: array<string>,
+  routeDepth: int,
   routesByName: dict<routeEntry>,
 }
 
@@ -231,6 +233,7 @@ type rec printableRoute = {
   queryParams: dict<queryParam>,
   slots: array<string>,
   outlet: option<string>,
+  entrypoint: bool,
   sourceFile: string,
 }
 

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Utils.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Utils.res
@@ -205,6 +205,7 @@ and parsedToPrintable = (routeEntry: routeEntry): printableRoute => {
   ->Dict.fromArray,
   slots: routeEntry.slots->Array.map(slot => slot.name.text),
   outlet: routeEntry.outlet->Option.map(outlet => outlet.text),
+  entrypoint: routeEntry.entrypoint,
   sourceFile: routeEntry.sourceFile,
 }
 

--- a/packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res
+++ b/packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res
@@ -13,6 +13,8 @@ external mkdirRecursiveSync: (string, @as(json`{"recursive":true}`) _) => unit =
 @module("fs") external readFileSync: (string, @as(json`"utf-8"`) _) => string = "readFileSync"
 @module("fs")
 external rmSync: (string, @as(json`{"recursive":true,"force":true}`) _) => unit = "rmSync"
+@send external indexOfFrom: (string, string, int) => int = "indexOf"
+@send external slice: (string, int, int) => string = "slice"
 
 let stringifyDump = dumped =>
   dumped->Array.map(route => JSON.Object(route))->JSON.Array->JSON.stringify
@@ -55,6 +57,12 @@ let withGeneratedRoutes = (routesJson, callback) => {
 
 let readGeneratedFile = (~generatedPath, ~fileName) =>
   readFileSync(Bindings.Path.join([generatedPath, fileName]))
+
+let sliceBetween = (content, ~startMarker, ~endMarker) => {
+  let start = content->String.indexOf(startMarker)
+  let end_ = content->indexOfFrom(endMarker, start + startMarker->String.length)
+  content->slice(start, end_)
+}
 
 describe("Query params", () => {
   test("turns param type to string", _t => {
@@ -188,6 +196,99 @@ describe("Route slots", () => {
         )->Expect.String.toContain(`<RelayRouter.Slot routeName="Shell" slotName="Overlay" ?fallback />`)
         expect(routeDeclarations)->Expect.String.toContain(`slots: ["Overlay"]`)
         expect(routeDeclarations)->Expect.String.toContain(`outlet: Some("Overlay")`)
+      },
+    )
+  })
+})
+
+describe("Route declarations", () => {
+  test("generates standalone make modules only for top-level routes marked entrypoint", _t => {
+    withGeneratedRoutes(
+      `[
+        {
+          "name": "Root",
+          "path": "/",
+          "children": [
+            {
+              "name": "Dashboard",
+              "path": "dashboard"
+            }
+          ]
+        },
+        {
+          "name": "Admin",
+          "path": "/admin",
+          "entrypoint": true,
+          "children": [
+            {
+              "name": "Users",
+              "path": "users"
+            }
+          ]
+        },
+        {
+          "name": "Embedded",
+          "path": "/embedded",
+          "entrypoint": false
+        }
+      ]`,
+      (~generatedPath) => {
+        let routeDeclarations = readGeneratedFile(~generatedPath, ~fileName="RouteDeclarations.res")
+        let routeDeclarationsInterface = readGeneratedFile(
+          ~generatedPath,
+          ~fileName="RouteDeclarations.resi",
+        )
+
+        expect(routeDeclarations)->Expect.String.toContain("module Admin = {")
+        expect(routeDeclarations)->Expect.String.toContain(
+          "let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> =>",
+        )
+        let adminModule =
+          routeDeclarations->sliceBetween(
+            ~startMarker="module Admin = {",
+            ~endMarker="\n\nlet make = (~prepareDisposeTimeout",
+          )
+        expect(adminModule)->Expect.String.toContain(`let routeName = "Admin"`)
+        expect(adminModule)->Expect.String.toContain(`let routeName = "Admin__Users"`)
+        expect(adminModule)->Expect.not->Expect.String.toContain(`let routeName = "Root"`)
+        expect(adminModule)->Expect.not->Expect.String.toContain(`let routeName = "Embedded"`)
+        expect(
+          routeDeclarations,
+        )->Expect.String.toContain(`let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> =>`)
+        expect(routeDeclarations)->Expect.not->Expect.String.toContain("module Root = {")
+        expect(routeDeclarations)->Expect.not->Expect.String.toContain("module Embedded = {")
+
+        expect(routeDeclarationsInterface)->Expect.String.toContain("module Admin: {")
+        expect(routeDeclarationsInterface)->Expect.String.toContain(
+          "let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>",
+        )
+        expect(routeDeclarationsInterface)->Expect.not->Expect.String.toContain("module Root:")
+        expect(routeDeclarationsInterface)->Expect.not->Expect.String.toContain("module Embedded:")
+      },
+    )
+  })
+
+  test("preserves the existing all-routes RouteDeclarations.make output", _t => {
+    withGeneratedRoutes(
+      `[
+        {
+          "name": "Root",
+          "path": "/"
+        },
+        {
+          "name": "Admin",
+          "path": "/admin",
+          "entrypoint": true
+        }
+      ]`,
+      (~generatedPath) => {
+        let routeDeclarations = readGeneratedFile(~generatedPath, ~fileName="RouteDeclarations.res")
+
+        expect(
+          routeDeclarations,
+        )->Expect.String.toContain(`let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> =>`)
+        expect(routeDeclarations)->Expect.String.toContain(`let routeName = "Root"`)
+        expect(routeDeclarations)->Expect.String.toContain(`let routeName = "Admin"`)
       },
     )
   })

--- a/packages/rescript-relay-router/test/RescriptRelayRouterCli__Parser_test.test.res
+++ b/packages/rescript-relay-router/test/RescriptRelayRouterCli__Parser_test.test.res
@@ -129,6 +129,23 @@ describe("Parsing", () => {
     }
   })
 
+  test("allows entrypoint on top-level routes", _t => {
+    let {errors, result} = parseRouteStructure(`[
+      {
+        "name": "Admin",
+        "path": "/admin",
+        "entrypoint": true
+      }
+    ]`)
+
+    suite->assertions(2)
+    expect(errors)->Expect.Array.toHaveLength(0)
+    switch result {
+    | [RouteEntry({entrypoint})] => expect(entrypoint)->Expect.toBe(true)
+    | _ => ()
+    }
+  })
+
   test("reports outlets without ancestor slot declarations", _t => {
     let {errors} = parseRouteStructure(`[
       {
@@ -147,5 +164,39 @@ describe("Parsing", () => {
     expect(
       errors->Array.map(error => error.message),
     )->Expect.Array.toContain(`Outlet "Overlay" does not match a slot declared by an ancestor route.`)
+  })
+
+  test("reports entrypoint on nested routes", _t => {
+    let {errors} = parseRouteStructure(`[
+      {
+        "name": "Root",
+        "path": "/",
+        "children": [
+          {
+            "name": "Settings",
+            "path": "settings",
+            "entrypoint": true
+          }
+        ]
+      }
+    ]`)
+
+    expect(
+      errors->Array.map(error => error.message),
+    )->Expect.Array.toContain(`"entrypoint" can only be used on top-level routes.`)
+  })
+
+  test("reports non-boolean entrypoint values", _t => {
+    let {errors} = parseRouteStructure(`[
+      {
+        "name": "Admin",
+        "path": "/admin",
+        "entrypoint": "true"
+      }
+    ]`)
+
+    expect(
+      errors->Array.map(error => error.message),
+    )->Expect.Array.toContain(`"entrypoint" needs to be a boolean. Found string("true").`)
   })
 })

--- a/packages/rescript-relay-router/test/RescriptRelayRouterCli__Parser_test.test.res
+++ b/packages/rescript-relay-router/test/RescriptRelayRouterCli__Parser_test.test.res
@@ -199,4 +199,18 @@ describe("Parsing", () => {
       errors->Array.map(error => error.message),
     )->Expect.Array.toContain(`"entrypoint" needs to be a boolean. Found string("true").`)
   })
+
+  test("reports entrypoint route names that shadow the router runtime module", _t => {
+    let {errors} = parseRouteStructure(`[
+      {
+        "name": "RelayRouter",
+        "path": "/router",
+        "entrypoint": true
+      }
+    ]`)
+
+    expect(
+      errors->Array.map(error => error.message),
+    )->Expect.Array.toContain(`"RelayRouter" cannot be used as an entrypoint route name because it would shadow the router runtime module in generated route declarations.`)
+  })
 })

--- a/plans/2026-05-19-route-declaration-entrypoints.md
+++ b/plans/2026-05-19-route-declaration-entrypoints.md
@@ -1,0 +1,42 @@
+# Route Declaration Entrypoints Plan
+
+Date: 2026-05-19
+
+## Decision
+
+Add `entrypoint: true` for top-level routes.
+
+Marked routes get a generated `RouteDeclarations.<RouteName>.make()` module that returns only that
+top-level route tree. The existing `RouteDeclarations.make()` continues to return every top-level
+route tree.
+
+## Who
+
+zth-linzumi asked Codex to take the old `task/separately-renderable-roots` work through to a PR
+after typed route slots landed. Codex renamed the config field from `separatelyRenderable` to
+`entrypoint` while rebasing the implementation onto latest `main`.
+
+## Why
+
+Typed route slots cover outlet placement inside a matched route tree. Entrypoints cover a separate
+need: constructing a router that matches, prepares, preloads, and renders only one top-level route
+tree for multi-entry apps, embedded apps, admin surfaces, or isolated route roots.
+
+## Verification
+
+- Parser tests cover valid top-level `entrypoint: true`, nested `entrypoint`, and non-boolean
+  `entrypoint` values.
+- Codegen tests cover generated standalone `RouteDeclarations.<RouteName>.make()` modules and
+  preservation of the all-routes `RouteDeclarations.make()`.
+- Ran `yarn workspaces foreach run rescript format -all`.
+- Ran `yarn build`.
+- Ran `yarn test`.
+- Ran `yarn install --immutable`.
+- Ran `yarn changeset status --since origin/main`.
+- Ran `git diff --check`.
+
+## Non-Goals
+
+- This does not change route-slot behavior.
+- This does not make nested routes independently renderable.
+- This does not remove or narrow the existing all-routes `RouteDeclarations.make()` entrypoint.

--- a/plans/2026-05-19-route-declaration-entrypoints.md
+++ b/plans/2026-05-19-route-declaration-entrypoints.md
@@ -10,11 +10,16 @@ Marked routes get a generated `RouteDeclarations.<RouteName>.make()` module that
 top-level route tree. The existing `RouteDeclarations.make()` continues to return every top-level
 route tree.
 
+Do not allow `RelayRouter` as an entrypoint route name. That generated module would shadow the
+router runtime module in `RouteDeclarations`.
+
 ## Who
 
 zth-linzumi asked Codex to take the old `task/separately-renderable-roots` work through to a PR
 after typed route slots landed. Codex renamed the config field from `separatelyRenderable` to
 `entrypoint` while rebasing the implementation onto latest `main`.
+Codex also reserved `RelayRouter` for entrypoint routes after PR review identified the generated
+module shadowing risk.
 
 ## Why
 
@@ -26,6 +31,7 @@ tree for multi-entry apps, embedded apps, admin surfaces, or isolated route root
 
 - Parser tests cover valid top-level `entrypoint: true`, nested `entrypoint`, and non-boolean
   `entrypoint` values.
+- Parser tests cover rejecting the `RelayRouter` entrypoint route name.
 - Codegen tests cover generated standalone `RouteDeclarations.<RouteName>.make()` modules and
   preservation of the all-routes `RouteDeclarations.make()`.
 - Ran `yarn workspaces foreach run rescript format -all`.


### PR DESCRIPTION
## Summary

- adds `entrypoint: true` for top-level routes
- generates standalone `RouteDeclarations.<RouteName>.make()` modules for marked route roots
- keeps the existing all-routes `RouteDeclarations.make()` behavior unchanged
- documents the API, adds parser/codegen coverage, adds a changeset, and records the decision in `plans/`

## Notes

- Rebuilt from `task/separately-renderable-roots` on top of current `main` after typed route slots merged.
- Renamed the config field from `separatelyRenderable` to `entrypoint`.
- The unrelated router optimization docs commit from the old branch was intentionally not included.

## Validation

- `yarn workspaces foreach run rescript format -all`
- `yarn build`
- `yarn test`
- `yarn install --immutable`
- `yarn changeset status --since origin/main`
- `git diff --check`
