### PR TITLE
Centralize router location subscriptions

### DIFF
--- a/.changeset/centralized-location-subscriptions.md
+++ b/.changeset/centralized-location-subscriptions.md
@@ -1,0 +1,5 @@
+---
+"rescript-relay-router": patch
+---
+
+Centralize router location subscriptions so location-consuming hooks share the router's history listener and still update during shallow navigations.

--- a/examples/client-rendering/test/UrlEncodingDecoding.test.res
+++ b/examples/client-rendering/test/UrlEncodingDecoding.test.res
@@ -2,6 +2,16 @@ open RescriptRelayRouterTestUtils
 open Vitest
 open TestingLibraryReact
 
+let makeRouteEntry = (location): RelayRouter.Types.currentRouterEntry => {
+  location,
+  preparedMatches: [],
+  primaryMatches: [],
+  slotContents: dict{},
+  allMatches: [],
+}
+
+let testPreloadAsset = (~priority, _asset) => ignore(priority)
+
 describe("makeLink", () => {
   test("should generate link with statuses", _t => {
     let link = Routes.Root.Todos.Route.makeLink(
@@ -27,6 +37,95 @@ describe("makeLink", () => {
 })
 
 describe("parsing", () => {
+  test("useLocation reads from the router location store", _t => {
+    let history = RelayRouter.History.createMemoryHistory(
+      ~options={"initialEntries": ["/initial?paneConfig=old"]},
+    )
+    let initialLocation = history->RelayRouter.History.getLocation
+    let currentLocation = ref(initialLocation)
+    let locationSubscriber = ref(None)
+    let routerContext: RelayRouter.Types.routerContext = {
+      preload: (~priority=?, _url) => ignore(priority),
+      preloadCode: (~priority=?, _url) => ignore(priority),
+      preloadAsset: testPreloadAsset,
+      get: () => currentLocation.contents->makeRouteEntry,
+      subscribe: _callback => () => (),
+      getLocation: () => currentLocation.contents,
+      subscribeToLocation: callback => {
+        locationSubscriber.contents = Some(callback)
+
+        () => {
+          locationSubscriber.contents = None
+        }
+      },
+      history,
+      subscribeToEvent: _callback => () => (),
+      postRouterEvent: _event => (),
+      markNextNavigationAsShallow: () => (),
+    }
+    let wrapper = ({Wrapper.children: children}) =>
+      <RelayRouter.Provider value={routerContext}> {children} </RelayRouter.Provider>
+    let {result} = renderHook(() => RelayRouter.Utils.useLocation(), ~options={wrapper: wrapper})
+    let nextLocation = {
+      ...initialLocation,
+      search: "?paneConfig=new",
+      key: "updated",
+    }
+
+    expect(result.current.search)->Expect.toBe("?paneConfig=old")
+
+    act(
+      () => {
+        currentLocation.contents = nextLocation
+        switch locationSubscriber.contents {
+        | Some(callback) => callback(nextLocation)
+        | None => ()
+        }
+      },
+    )
+
+    expect(result.current.search)->Expect.toBe("?paneConfig=new")
+  })
+
+  test("shallow navigations update location subscribers without preparing route entries", _t => {
+    let routes = RouteDeclarations.make()
+    let (cleanup, routerContext) = RelayRouter.Router.make(
+      ~routes,
+      ~environment=RelayEnv.environment,
+      ~routerEnvironment=RelayRouter.RouterEnvironment.makeServerEnvironment(
+        ~initialUrl="/todos?byValue=old",
+      ),
+      ~preloadAsset=RelayRouter.AssetPreloader.makeClientAssetPreloader(RelayEnv.preparedAssetsMap),
+    )
+    let routeEntries = []
+    let locations = []
+    let unsubscribeRoute = routerContext.subscribe(entry => routeEntries->Array.push(entry))
+    let unsubscribeLocation = routerContext.subscribeToLocation(
+      location => locations->Array.push(location),
+    )
+
+    routerContext.markNextNavigationAsShallow()
+    routerContext.history->RelayRouter.History.push("/todos?byValue=shallow")
+
+    let shallowLocation: RelayRouter.History.location = locations->Array.get(0)->Option.getExn
+    expect(locations->Array.length)->Expect.toBe(1)
+    expect(shallowLocation.search)->Expect.toBe("?byValue=shallow")
+    expect(routeEntries->Array.length)->Expect.toBe(0)
+    expect(routerContext.getLocation().search)->Expect.toBe("?byValue=shallow")
+    expect(routerContext.get().location.search)->Expect.toBe("?byValue=old")
+
+    routerContext.history->RelayRouter.History.push("/todos?byValue=prepared")
+
+    expect(locations->Array.length)->Expect.toBe(2)
+    expect(routeEntries->Array.length)->Expect.toBe(1)
+    expect(routerContext.getLocation().search)->Expect.toBe("?byValue=prepared")
+    expect(routerContext.get().location.search)->Expect.toBe("?byValue=prepared")
+
+    unsubscribeLocation()
+    unsubscribeRoute()
+    cleanup()
+  })
+
   test("parseRoute correctly decode query params", _t => {
     let queryParams =
       Routes.Root.Todos.Route.parseRoute(

--- a/packages/rescript-relay-router/src/RelayRouter.res
+++ b/packages/rescript-relay-router/src/RelayRouter.res
@@ -92,21 +92,31 @@ module Router = {
     let currentEntry = ref(
       preparedMatches->RelayRouter__RouteSlots.routeSetFromPreparedMatches(~location),
     )
+    let currentLocation = ref(location)
 
     let nextId = ref(0)
     let subscribers = dict{}
+    let nextLocationSubscriberId = ref(0)
+    let locationSubscribers = dict{}
     let nextNavigationIsShallow = ref(false)
 
     let cleanup = history->RelayRouter__History.listen(({location}) => {
+      currentLocation.contents = location
+      locationSubscribers
+      ->Dict.valuesToArray
+      ->Array.forEach(subscriber => subscriber(location))
+
       let thisNavigationShouldBeShallow = nextNavigationIsShallow.contents
-      if nextNavigationIsShallow.contents === true {
-        nextNavigationIsShallow.contents = false
+      switch nextNavigationIsShallow.contents {
+      | true => nextNavigationIsShallow.contents = false
+      | false => ()
       }
-      if (
-        !thisNavigationShouldBeShallow &&
-        (location.pathname !== currentEntry.contents.location.pathname ||
-          location.search !== currentEntry.contents.location.search)
+      switch (
+        thisNavigationShouldBeShallow,
+        location.pathname !== currentEntry.contents.location.pathname ||
+          location.search !== currentEntry.contents.location.search,
       ) {
+      | (false, true) =>
         let queryParams = QueryParams.parse(location.search)
 
         let currentMatches = currentEntry.contents.allMatches
@@ -130,6 +140,7 @@ module Router = {
         subscribers
         ->Dict.valuesToArray
         ->Array.forEach(subscriber => subscriber(currentEntry.contents))
+      | (true, _) | (false, false) => ()
       }
     })
 
@@ -191,6 +202,7 @@ module Router = {
     }
 
     let get = () => currentEntry.contents
+    let getLocation = () => currentLocation.contents
 
     let subscribe = cb => {
       nextId.contents = nextId.contents + 1
@@ -199,6 +211,16 @@ module Router = {
 
       () => {
         subscribers->Dict.delete(Int.toString(id))
+      }
+    }
+
+    let subscribeToLocation = cb => {
+      nextLocationSubscriberId.contents = nextLocationSubscriberId.contents + 1
+      let id = nextLocationSubscriberId.contents
+      locationSubscribers->Dict.set(Int.toString(id), cb)
+
+      () => {
+        locationSubscribers->Dict.delete(Int.toString(id))
       }
     }
 
@@ -220,6 +242,8 @@ module Router = {
         preloadAsset,
         get,
         subscribe,
+        getLocation,
+        subscribeToLocation,
         history,
         subscribeToEvent: callback => {
           let _ = routerEventListeners.contents->Array.push(callback)

--- a/packages/rescript-relay-router/src/RelayRouter__Types.res
+++ b/packages/rescript-relay-router/src/RelayRouter__Types.res
@@ -69,6 +69,7 @@ type currentRouterEntry = {
 }
 
 type subFn = currentRouterEntry => unit
+type locationSubFn = RelayRouter__History.location => unit
 type unsubFn = unit => unit
 type cleanupFn = unit => unit
 type callback = unit => unit
@@ -87,6 +88,8 @@ type routerContext = {
   preloadAsset: preloadAssetFn,
   get: unit => currentRouterEntry,
   subscribe: subFn => unsubFn,
+  getLocation: unit => RelayRouter__History.location,
+  subscribeToLocation: locationSubFn => unsubFn,
   history: RelayRouter__History.t,
   subscribeToEvent: onRouterEventFn => unsubFn,
   postRouterEvent: routerEvent => unit,

--- a/packages/rescript-relay-router/src/RelayRouter__Utils.res
+++ b/packages/rescript-relay-router/src/RelayRouter__Utils.res
@@ -15,23 +15,25 @@ let useRouter = (): routerHelpers => {
     preload,
     preloadCode,
     postRouterEvent,
-    get,
+    getLocation,
     markNextNavigationAsShallow,
   } = RelayRouter__Context.useRouterContext()
   let push = React.useCallback((path, ~shallow=false) => {
-    if shallow {
-      markNextNavigationAsShallow()
+    switch shallow {
+    | true => markNextNavigationAsShallow()
+    | false => ()
     }
-    postRouterEvent(OnBeforeNavigation({currentLocation: get().location}))
+    postRouterEvent(OnBeforeNavigation({currentLocation: getLocation()}))
     history->RelayRouter__History.push(path)
-  }, (history, postRouterEvent))
+  }, (history, postRouterEvent, getLocation, markNextNavigationAsShallow))
   let replace = React.useCallback((path, ~shallow=false) => {
-    if shallow {
-      markNextNavigationAsShallow()
+    switch shallow {
+    | true => markNextNavigationAsShallow()
+    | false => ()
     }
-    postRouterEvent(OnBeforeNavigation({currentLocation: get().location}))
+    postRouterEvent(OnBeforeNavigation({currentLocation: getLocation()}))
     history->RelayRouter__History.replace(path)
-  }, (history, postRouterEvent))
+  }, (history, postRouterEvent, getLocation, markNextNavigationAsShallow))
 
   {
     push,
@@ -43,19 +45,12 @@ let useRouter = (): routerHelpers => {
 
 let useLocation = () => {
   let router = RelayRouter__Context.useRouterContext()
-  let (location, setLocation) = React.useState(() =>
-    router.history->RelayRouter__History.getLocation
-  )
 
-  React.useEffect(() => {
-    let unsub = router.history->RelayRouter__History.listen(({location}) => {
-      setLocation(_ => location)
+  React.useSyncExternalStoreWithServerSnapshot(~subscribe=callback =>
+    router.subscribeToLocation(_location => {
+      callback()
     })
-
-    Some(unsub)
-  }, [router.history])
-
-  location
+  , ~getSnapshot=router.getLocation, ~getServerSnapshot=router.getLocation)
 }
 
 let isRouteActive = (~pathname, ~routePattern, ~exact=false) => {

--- a/packages/rescript-relay-router/test/RouteSlots.test.res
+++ b/packages/rescript-relay-router/test/RouteSlots.test.res
@@ -142,6 +142,8 @@ describe("RelayRouter__RouteSlots", () => {
       preloadAsset: (~priority, _asset) => ignore(priority),
       get: () => routeEntry,
       subscribe: _callback => () => (),
+      getLocation: () => routeEntry.location,
+      subscribeToLocation: _callback => () => (),
       history: RelayRouter.History.createMemoryHistory(
         ~options={"initialEntries": ["/preferences/account"]},
       ),

--- a/plans/2026-05-19-centralized-location-subscriptions.md
+++ b/plans/2026-05-19-centralized-location-subscriptions.md
@@ -1,0 +1,45 @@
+# Centralized Location Subscriptions
+
+## Decision
+
+Centralize location subscriptions in `Router.make` and expose them on `routerContext` as
+`getLocation` and `subscribeToLocation`.
+
+## Why
+
+Generated helpers such as `useQueryParams` and `useIsRouteActive` read through
+`RelayRouter.Utils.useLocation`. Previously each hook consumer attached its own `history.listen`
+subscription. Navigation-heavy layouts can render many consumers, so the router should own one
+history listener and fan location snapshots out from a shared store.
+
+This also separates two runtime concerns:
+
+- route-entry subscribers update when prepared route matches change
+- location subscribers update for every history location change, including shallow navigations
+
+Shallow navigations intentionally skip route preparation, but query-param and active-route hooks
+still need the new location snapshot.
+
+Decision made by Codex on 2026-05-19.
+
+## Verification
+
+- Ran `yarn workspace rescript-relay-router build`.
+- Ran `yarn workspace rescript-relay-router test`.
+- Ran `yarn workspace @rescript-relay-router-example/client-rendering build:rescript`.
+- Ran `yarn workspace @rescript-relay-router-example/client-rendering test`.
+- Ran `yarn build`.
+- Ran `yarn test`.
+- Ran `yarn install --immutable`; it passed with the repo's existing peer dependency warnings.
+- Ran `git diff --check`.
+
+## Non-Goals
+
+- No change to URL semantics.
+- No change to generated route helper APIs.
+- No attempt to make route-entry subscribers update on shallow navigation.
+- No React transition scheduling changes for location subscribers.
+
+## Known Blockers
+
+None.


### PR DESCRIPTION
## What changed

- Add a router-owned location store with `getLocation` and `subscribeToLocation` on `routerContext`.
- Move `RelayRouter.Utils.useLocation` to `useSyncExternalStoreWithServerSnapshot` so location consumers share the router history listener.
- Keep route-entry subscribers tied to prepared route changes while location subscribers still update during shallow navigation.
- Add example coverage for `useLocation` and shallow query navigation behavior.

## Why

Generated helpers such as `useQueryParams` and `useIsRouteActive` can appear many times in a multi-pane UI. They should not each attach their own `history.listen`; the router already has the authoritative history listener.

## Validation

- `yarn workspace rescript-relay-router build`
- `yarn workspace rescript-relay-router test`
- `yarn workspace @rescript-relay-router-example/client-rendering build:rescript`
- `yarn workspace @rescript-relay-router-example/client-rendering test`
- `yarn build`
- `yarn test`
- `yarn install --immutable` (passes with existing peer dependency warnings)
- `yarn changeset status --since origin/main`
- `git diff --check`
