### PR TITLE
[codex] Add typed route targets

### DIFF
--- a/.changeset/typed-route-targets.md
+++ b/.changeset/typed-route-targets.md
@@ -1,0 +1,5 @@
+---
+"rescript-relay-router": minor
+---
+
+Generate typed route targets and expose the current matched route stack on router entries.

--- a/examples/client-rendering/src/routes/__generated__/Route__Root__Home_route.res
+++ b/examples/client-rendering/src/routes/__generated__/Route__Root__Home_route.res
@@ -46,6 +46,112 @@ let makeLink = () => {
 }
 
 @live
+type target = unit
+
+@live
+let targetFromMatchedRoute = (
+  matchedRoute: RelayRouter.Types.matchedRoute,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<target> =>
+  switch matchedRoute.routeName {
+  | "Root__Home" =>
+    ignore(queryParams)
+    Some(())
+  | _ => None
+  }
+
+@live
+let targetFromLocation = (location: RelayRouter.History.location): option<target> => {
+  let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+  switch RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": true}, location.pathname) {
+  | Some({params}) =>
+    targetFromMatchedRoute({
+      routeName: "Root__Home",
+      routeKey: "",
+      pathParams: params,
+      slots: [],
+      outlet: None,
+    }, ~queryParams)
+  | None => None
+  }
+}
+
+@live
+let targetToPath = (_target: target): string => makeLink()
+
+@live
+let targetKey = targetToPath
+
+@live
+let targetRouteName = "Root__Home"
+
+module Target = {
+  @live
+  type t =
+    | Self(target)
+
+  let fromMatchedRoute = (
+    matchedRoute: RelayRouter.Types.matchedRoute,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch matchedRoute.routeName {
+    | "Root__Home" =>
+      targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Self(target)
+      )
+    | _ => None
+    }
+
+  let fromEntryWithQueryParams = (
+    entry: RelayRouter.Types.currentRouterEntry,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch entry.matchedRoutes->Array.toReversed->Array.get(0) {
+    | Some(matchedRoute) => fromMatchedRoute(matchedRoute, ~queryParams)
+    | None => None
+    }
+
+  let fromEntry = (entry: RelayRouter.Types.currentRouterEntry): option<t> =>
+    fromEntryWithQueryParams(entry, ~queryParams=entry.queryParams)
+
+  let useCurrent = (): option<t> => {
+    let router = RelayRouter.useRouterContext()
+    let location = RelayRouter.Utils.useLocation()
+    let (entry, setEntry) = React.useState(() => router.get())
+
+    React.useEffect(() => {
+      let dispose = router.subscribe(nextEntry => setEntry(_ => nextEntry))
+      Some(dispose)
+    }, [router])
+
+    React.useMemo(() => {
+      let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+      fromEntryWithQueryParams(entry, ~queryParams)
+    }, (entry, location.search))
+  }
+
+  let fromLocation = (location: RelayRouter.History.location): option<t> =>
+    switch targetFromLocation(location) {
+    | Some(target) => Some(Self(target))
+    | None =>
+      None
+    }
+
+  let toPath = (target: t): string =>
+    switch target {
+    | Self(target) => targetToPath(target)
+    }
+
+  let key = toPath
+
+  let routeName = (target: t): string =>
+    switch target {
+    | Self(_) => "Root__Home"
+    }
+
+}
+
+@live
 let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Option.isSome
 }

--- a/examples/client-rendering/src/routes/__generated__/Route__Root__PathParamsOnly_route.res
+++ b/examples/client-rendering/src/routes/__generated__/Route__Root__PathParamsOnly_route.res
@@ -53,6 +53,117 @@ let makeLink = (~pageSlug: string) => {
 }
 
 @live
+type target = {
+  pageSlug: string,
+}
+
+@live
+let targetFromMatchedRoute = (
+  matchedRoute: RelayRouter.Types.matchedRoute,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<target> =>
+  switch matchedRoute.routeName {
+  | "Root__PathParamsOnly" =>
+    ignore(queryParams)
+    Some({
+      pageSlug: matchedRoute.pathParams->Dict.getUnsafe("pageSlug"),
+    })
+  | _ => None
+  }
+
+@live
+let targetFromLocation = (location: RelayRouter.History.location): option<target> => {
+  let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+  switch RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": true}, location.pathname) {
+  | Some({params}) =>
+    targetFromMatchedRoute({
+      routeName: "Root__PathParamsOnly",
+      routeKey: "",
+      pathParams: params,
+      slots: [],
+      outlet: None,
+    }, ~queryParams)
+  | None => None
+  }
+}
+
+@live
+let targetToPath = (target: target): string =>
+  makeLink(~pageSlug=target.pageSlug)
+
+@live
+let targetKey = targetToPath
+
+@live
+let targetRouteName = "Root__PathParamsOnly"
+
+module Target = {
+  @live
+  type t =
+    | Self(target)
+
+  let fromMatchedRoute = (
+    matchedRoute: RelayRouter.Types.matchedRoute,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch matchedRoute.routeName {
+    | "Root__PathParamsOnly" =>
+      targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Self(target)
+      )
+    | _ => None
+    }
+
+  let fromEntryWithQueryParams = (
+    entry: RelayRouter.Types.currentRouterEntry,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch entry.matchedRoutes->Array.toReversed->Array.get(0) {
+    | Some(matchedRoute) => fromMatchedRoute(matchedRoute, ~queryParams)
+    | None => None
+    }
+
+  let fromEntry = (entry: RelayRouter.Types.currentRouterEntry): option<t> =>
+    fromEntryWithQueryParams(entry, ~queryParams=entry.queryParams)
+
+  let useCurrent = (): option<t> => {
+    let router = RelayRouter.useRouterContext()
+    let location = RelayRouter.Utils.useLocation()
+    let (entry, setEntry) = React.useState(() => router.get())
+
+    React.useEffect(() => {
+      let dispose = router.subscribe(nextEntry => setEntry(_ => nextEntry))
+      Some(dispose)
+    }, [router])
+
+    React.useMemo(() => {
+      let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+      fromEntryWithQueryParams(entry, ~queryParams)
+    }, (entry, location.search))
+  }
+
+  let fromLocation = (location: RelayRouter.History.location): option<t> =>
+    switch targetFromLocation(location) {
+    | Some(target) => Some(Self(target))
+    | None =>
+      None
+    }
+
+  let toPath = (target: t): string =>
+    switch target {
+    | Self(target) => targetToPath(target)
+    }
+
+  let key = toPath
+
+  let routeName = (target: t): string =>
+    switch target {
+    | Self(_) => "Root__PathParamsOnly"
+    }
+
+}
+
+@live
 let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Option.isSome
 }

--- a/examples/client-rendering/src/routes/__generated__/Route__Root__Settings_route.res
+++ b/examples/client-rendering/src/routes/__generated__/Route__Root__Settings_route.res
@@ -46,6 +46,112 @@ let makeLink = () => {
 }
 
 @live
+type target = unit
+
+@live
+let targetFromMatchedRoute = (
+  matchedRoute: RelayRouter.Types.matchedRoute,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<target> =>
+  switch matchedRoute.routeName {
+  | "Root__Settings" =>
+    ignore(queryParams)
+    Some(())
+  | _ => None
+  }
+
+@live
+let targetFromLocation = (location: RelayRouter.History.location): option<target> => {
+  let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+  switch RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": true}, location.pathname) {
+  | Some({params}) =>
+    targetFromMatchedRoute({
+      routeName: "Root__Settings",
+      routeKey: "",
+      pathParams: params,
+      slots: [],
+      outlet: None,
+    }, ~queryParams)
+  | None => None
+  }
+}
+
+@live
+let targetToPath = (_target: target): string => makeLink()
+
+@live
+let targetKey = targetToPath
+
+@live
+let targetRouteName = "Root__Settings"
+
+module Target = {
+  @live
+  type t =
+    | Self(target)
+
+  let fromMatchedRoute = (
+    matchedRoute: RelayRouter.Types.matchedRoute,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch matchedRoute.routeName {
+    | "Root__Settings" =>
+      targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Self(target)
+      )
+    | _ => None
+    }
+
+  let fromEntryWithQueryParams = (
+    entry: RelayRouter.Types.currentRouterEntry,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch entry.matchedRoutes->Array.toReversed->Array.get(0) {
+    | Some(matchedRoute) => fromMatchedRoute(matchedRoute, ~queryParams)
+    | None => None
+    }
+
+  let fromEntry = (entry: RelayRouter.Types.currentRouterEntry): option<t> =>
+    fromEntryWithQueryParams(entry, ~queryParams=entry.queryParams)
+
+  let useCurrent = (): option<t> => {
+    let router = RelayRouter.useRouterContext()
+    let location = RelayRouter.Utils.useLocation()
+    let (entry, setEntry) = React.useState(() => router.get())
+
+    React.useEffect(() => {
+      let dispose = router.subscribe(nextEntry => setEntry(_ => nextEntry))
+      Some(dispose)
+    }, [router])
+
+    React.useMemo(() => {
+      let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+      fromEntryWithQueryParams(entry, ~queryParams)
+    }, (entry, location.search))
+  }
+
+  let fromLocation = (location: RelayRouter.History.location): option<t> =>
+    switch targetFromLocation(location) {
+    | Some(target) => Some(Self(target))
+    | None =>
+      None
+    }
+
+  let toPath = (target: t): string =>
+    switch target {
+    | Self(target) => targetToPath(target)
+    }
+
+  let key = toPath
+
+  let routeName = (target: t): string =>
+    switch target {
+    | Self(_) => "Root__Settings"
+    }
+
+}
+
+@live
 let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Option.isSome
 }

--- a/examples/client-rendering/src/routes/__generated__/Route__Root__Todos__ByStatusDecodedExtra_route.res
+++ b/examples/client-rendering/src/routes/__generated__/Route__Root__Todos__ByStatusDecodedExtra_route.res
@@ -147,6 +147,123 @@ let makeLinkFromQueryParams = (~byStatusDecoded: TodoStatusPathParam.t, queryPar
 let useMakeLinkWithPreservedPath = (): ((queryParams => queryParams) => string) => RelayRouter__Internal.useMakeLinkWithPreservedPath(~parseQueryParams=Internal.parseQueryParams, ~applyQueryParams)
 
 @live
+type target = {
+  byStatusDecoded: TodoStatusPathParam.t,
+  statuses: option<array<TodoStatus.t>>,
+  statusWithDefault: TodoStatus.t,
+  byValue: option<string>,
+}
+
+@live
+let targetFromMatchedRoute = (
+  matchedRoute: RelayRouter.Types.matchedRoute,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<target> =>
+  switch matchedRoute.routeName {
+  | "Root__Todos__ByStatusDecodedExtra" =>
+    let decodedQueryParams = Internal.parseQueryParams(queryParams)
+    Some({
+      byStatusDecoded: matchedRoute.pathParams->Dict.getUnsafe("byStatusDecoded")->((byStatusDecodedRawAsString: string) => (byStatusDecodedRawAsString :> TodoStatusPathParam.t)),
+      statuses: decodedQueryParams.statuses,
+      statusWithDefault: decodedQueryParams.statusWithDefault,
+      byValue: decodedQueryParams.byValue,
+    })
+  | _ => None
+  }
+
+@live
+let targetFromLocation = (location: RelayRouter.History.location): option<target> => {
+  let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+  switch RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": true}, location.pathname) {
+  | Some({params}) =>
+    targetFromMatchedRoute({
+      routeName: "Root__Todos__ByStatusDecodedExtra",
+      routeKey: "",
+      pathParams: params,
+      slots: [],
+      outlet: None,
+    }, ~queryParams)
+  | None => None
+  }
+}
+
+@live
+let targetToPath = (target: target): string =>
+  makeLink(~byStatusDecoded=target.byStatusDecoded, ~statuses=?target.statuses, ~statusWithDefault=target.statusWithDefault, ~byValue=?target.byValue)
+
+@live
+let targetKey = targetToPath
+
+@live
+let targetRouteName = "Root__Todos__ByStatusDecodedExtra"
+
+module Target = {
+  @live
+  type t =
+    | Self(target)
+
+  let fromMatchedRoute = (
+    matchedRoute: RelayRouter.Types.matchedRoute,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch matchedRoute.routeName {
+    | "Root__Todos__ByStatusDecodedExtra" =>
+      targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Self(target)
+      )
+    | _ => None
+    }
+
+  let fromEntryWithQueryParams = (
+    entry: RelayRouter.Types.currentRouterEntry,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch entry.matchedRoutes->Array.toReversed->Array.get(0) {
+    | Some(matchedRoute) => fromMatchedRoute(matchedRoute, ~queryParams)
+    | None => None
+    }
+
+  let fromEntry = (entry: RelayRouter.Types.currentRouterEntry): option<t> =>
+    fromEntryWithQueryParams(entry, ~queryParams=entry.queryParams)
+
+  let useCurrent = (): option<t> => {
+    let router = RelayRouter.useRouterContext()
+    let location = RelayRouter.Utils.useLocation()
+    let (entry, setEntry) = React.useState(() => router.get())
+
+    React.useEffect(() => {
+      let dispose = router.subscribe(nextEntry => setEntry(_ => nextEntry))
+      Some(dispose)
+    }, [router])
+
+    React.useMemo(() => {
+      let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+      fromEntryWithQueryParams(entry, ~queryParams)
+    }, (entry, location.search))
+  }
+
+  let fromLocation = (location: RelayRouter.History.location): option<t> =>
+    switch targetFromLocation(location) {
+    | Some(target) => Some(Self(target))
+    | None =>
+      None
+    }
+
+  let toPath = (target: t): string =>
+    switch target {
+    | Self(target) => targetToPath(target)
+    }
+
+  let key = toPath
+
+  let routeName = (target: t): string =>
+    switch target {
+    | Self(_) => "Root__Todos__ByStatusDecodedExtra"
+    }
+
+}
+
+@live
 let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Option.isSome
 }

--- a/examples/client-rendering/src/routes/__generated__/Route__Root__Todos__ByStatusDecoded__Child_route.res
+++ b/examples/client-rendering/src/routes/__generated__/Route__Root__Todos__ByStatusDecoded__Child_route.res
@@ -147,6 +147,123 @@ let makeLinkFromQueryParams = (~byStatusDecoded: TodoStatusPathParam.t, queryPar
 let useMakeLinkWithPreservedPath = (): ((queryParams => queryParams) => string) => RelayRouter__Internal.useMakeLinkWithPreservedPath(~parseQueryParams=Internal.parseQueryParams, ~applyQueryParams)
 
 @live
+type target = {
+  byStatusDecoded: TodoStatusPathParam.t,
+  statuses: option<array<TodoStatus.t>>,
+  statusWithDefault: TodoStatus.t,
+  byValue: option<string>,
+}
+
+@live
+let targetFromMatchedRoute = (
+  matchedRoute: RelayRouter.Types.matchedRoute,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<target> =>
+  switch matchedRoute.routeName {
+  | "Root__Todos__ByStatusDecoded__Child" =>
+    let decodedQueryParams = Internal.parseQueryParams(queryParams)
+    Some({
+      byStatusDecoded: matchedRoute.pathParams->Dict.getUnsafe("byStatusDecoded")->((byStatusDecodedRawAsString: string) => (byStatusDecodedRawAsString :> TodoStatusPathParam.t)),
+      statuses: decodedQueryParams.statuses,
+      statusWithDefault: decodedQueryParams.statusWithDefault,
+      byValue: decodedQueryParams.byValue,
+    })
+  | _ => None
+  }
+
+@live
+let targetFromLocation = (location: RelayRouter.History.location): option<target> => {
+  let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+  switch RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": true}, location.pathname) {
+  | Some({params}) =>
+    targetFromMatchedRoute({
+      routeName: "Root__Todos__ByStatusDecoded__Child",
+      routeKey: "",
+      pathParams: params,
+      slots: [],
+      outlet: None,
+    }, ~queryParams)
+  | None => None
+  }
+}
+
+@live
+let targetToPath = (target: target): string =>
+  makeLink(~byStatusDecoded=target.byStatusDecoded, ~statuses=?target.statuses, ~statusWithDefault=target.statusWithDefault, ~byValue=?target.byValue)
+
+@live
+let targetKey = targetToPath
+
+@live
+let targetRouteName = "Root__Todos__ByStatusDecoded__Child"
+
+module Target = {
+  @live
+  type t =
+    | Self(target)
+
+  let fromMatchedRoute = (
+    matchedRoute: RelayRouter.Types.matchedRoute,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch matchedRoute.routeName {
+    | "Root__Todos__ByStatusDecoded__Child" =>
+      targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Self(target)
+      )
+    | _ => None
+    }
+
+  let fromEntryWithQueryParams = (
+    entry: RelayRouter.Types.currentRouterEntry,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch entry.matchedRoutes->Array.toReversed->Array.get(0) {
+    | Some(matchedRoute) => fromMatchedRoute(matchedRoute, ~queryParams)
+    | None => None
+    }
+
+  let fromEntry = (entry: RelayRouter.Types.currentRouterEntry): option<t> =>
+    fromEntryWithQueryParams(entry, ~queryParams=entry.queryParams)
+
+  let useCurrent = (): option<t> => {
+    let router = RelayRouter.useRouterContext()
+    let location = RelayRouter.Utils.useLocation()
+    let (entry, setEntry) = React.useState(() => router.get())
+
+    React.useEffect(() => {
+      let dispose = router.subscribe(nextEntry => setEntry(_ => nextEntry))
+      Some(dispose)
+    }, [router])
+
+    React.useMemo(() => {
+      let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+      fromEntryWithQueryParams(entry, ~queryParams)
+    }, (entry, location.search))
+  }
+
+  let fromLocation = (location: RelayRouter.History.location): option<t> =>
+    switch targetFromLocation(location) {
+    | Some(target) => Some(Self(target))
+    | None =>
+      None
+    }
+
+  let toPath = (target: t): string =>
+    switch target {
+    | Self(target) => targetToPath(target)
+    }
+
+  let key = toPath
+
+  let routeName = (target: t): string =>
+    switch target {
+    | Self(_) => "Root__Todos__ByStatusDecoded__Child"
+    }
+
+}
+
+@live
 let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Option.isSome
 }

--- a/examples/client-rendering/src/routes/__generated__/Route__Root__Todos__ByStatusDecoded_route.res
+++ b/examples/client-rendering/src/routes/__generated__/Route__Root__Todos__ByStatusDecoded_route.res
@@ -155,6 +155,134 @@ let makeLinkFromQueryParams = (~byStatusDecoded: TodoStatusPathParam.t, queryPar
 let useMakeLinkWithPreservedPath = (): ((queryParams => queryParams) => string) => RelayRouter__Internal.useMakeLinkWithPreservedPath(~parseQueryParams=Internal.parseQueryParams, ~applyQueryParams)
 
 @live
+type target = {
+  byStatusDecoded: TodoStatusPathParam.t,
+  statuses: option<array<TodoStatus.t>>,
+  statusWithDefault: TodoStatus.t,
+  byValue: option<string>,
+}
+
+@live
+let targetFromMatchedRoute = (
+  matchedRoute: RelayRouter.Types.matchedRoute,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<target> =>
+  switch matchedRoute.routeName {
+  | "Root__Todos__ByStatusDecoded" =>
+    let decodedQueryParams = Internal.parseQueryParams(queryParams)
+    Some({
+      byStatusDecoded: matchedRoute.pathParams->Dict.getUnsafe("byStatusDecoded")->((byStatusDecodedRawAsString: string) => (byStatusDecodedRawAsString :> TodoStatusPathParam.t)),
+      statuses: decodedQueryParams.statuses,
+      statusWithDefault: decodedQueryParams.statusWithDefault,
+      byValue: decodedQueryParams.byValue,
+    })
+  | _ => None
+  }
+
+@live
+let targetFromLocation = (location: RelayRouter.History.location): option<target> => {
+  let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+  switch RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": true}, location.pathname) {
+  | Some({params}) =>
+    targetFromMatchedRoute({
+      routeName: "Root__Todos__ByStatusDecoded",
+      routeKey: "",
+      pathParams: params,
+      slots: [],
+      outlet: None,
+    }, ~queryParams)
+  | None => None
+  }
+}
+
+@live
+let targetToPath = (target: target): string =>
+  makeLink(~byStatusDecoded=target.byStatusDecoded, ~statuses=?target.statuses, ~statusWithDefault=target.statusWithDefault, ~byValue=?target.byValue)
+
+@live
+let targetKey = targetToPath
+
+@live
+let targetRouteName = "Root__Todos__ByStatusDecoded"
+
+module Target = {
+  @live
+  type t =
+    | Self(target)
+    | Child(Route__Root__Todos__ByStatusDecoded__Child_route.target)
+
+  let fromMatchedRoute = (
+    matchedRoute: RelayRouter.Types.matchedRoute,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch matchedRoute.routeName {
+    | "Root__Todos__ByStatusDecoded" =>
+      targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Self(target)
+      )
+    | "Root__Todos__ByStatusDecoded__Child" =>
+      Route__Root__Todos__ByStatusDecoded__Child_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Child(target)
+      )
+    | _ => None
+    }
+
+  let fromEntryWithQueryParams = (
+    entry: RelayRouter.Types.currentRouterEntry,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch entry.matchedRoutes->Array.toReversed->Array.get(0) {
+    | Some(matchedRoute) => fromMatchedRoute(matchedRoute, ~queryParams)
+    | None => None
+    }
+
+  let fromEntry = (entry: RelayRouter.Types.currentRouterEntry): option<t> =>
+    fromEntryWithQueryParams(entry, ~queryParams=entry.queryParams)
+
+  let useCurrent = (): option<t> => {
+    let router = RelayRouter.useRouterContext()
+    let location = RelayRouter.Utils.useLocation()
+    let (entry, setEntry) = React.useState(() => router.get())
+
+    React.useEffect(() => {
+      let dispose = router.subscribe(nextEntry => setEntry(_ => nextEntry))
+      Some(dispose)
+    }, [router])
+
+    React.useMemo(() => {
+      let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+      fromEntryWithQueryParams(entry, ~queryParams)
+    }, (entry, location.search))
+  }
+
+  let fromLocation = (location: RelayRouter.History.location): option<t> =>
+    switch targetFromLocation(location) {
+    | Some(target) => Some(Self(target))
+    | None =>
+      switch Route__Root__Todos__ByStatusDecoded__Child_route.targetFromLocation(location) {
+      | Some(target) => Some(Child(target))
+      | None =>
+        None
+      }
+    }
+
+  let toPath = (target: t): string =>
+    switch target {
+    | Self(target) => targetToPath(target)
+    | Child(target) => Route__Root__Todos__ByStatusDecoded__Child_route.targetToPath(target)
+    }
+
+  let key = toPath
+
+  let routeName = (target: t): string =>
+    switch target {
+    | Self(_) => "Root__Todos__ByStatusDecoded"
+    | Child(_) => "Root__Todos__ByStatusDecoded__Child"
+    }
+
+}
+
+@live
 let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Option.isSome
 }

--- a/examples/client-rendering/src/routes/__generated__/Route__Root__Todos__ByStatus_route.res
+++ b/examples/client-rendering/src/routes/__generated__/Route__Root__Todos__ByStatus_route.res
@@ -151,6 +151,123 @@ let useMakeLinkWithPreservedPath = (): ((queryParams => queryParams) => string) 
 type pathParam_byStatus = [#"completed" | #"not-completed"]
 
 @live
+type target = {
+  byStatus: [#"completed" | #"not-completed"],
+  statuses: option<array<TodoStatus.t>>,
+  statusWithDefault: TodoStatus.t,
+  byValue: option<string>,
+}
+
+@live
+let targetFromMatchedRoute = (
+  matchedRoute: RelayRouter.Types.matchedRoute,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<target> =>
+  switch matchedRoute.routeName {
+  | "Root__Todos__ByStatus" =>
+    let decodedQueryParams = Internal.parseQueryParams(queryParams)
+    Some({
+      byStatus: matchedRoute.pathParams->Dict.getUnsafe("byStatus")->Obj.magic,
+      statuses: decodedQueryParams.statuses,
+      statusWithDefault: decodedQueryParams.statusWithDefault,
+      byValue: decodedQueryParams.byValue,
+    })
+  | _ => None
+  }
+
+@live
+let targetFromLocation = (location: RelayRouter.History.location): option<target> => {
+  let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+  switch RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": true}, location.pathname) {
+  | Some({params}) =>
+    targetFromMatchedRoute({
+      routeName: "Root__Todos__ByStatus",
+      routeKey: "",
+      pathParams: params,
+      slots: [],
+      outlet: None,
+    }, ~queryParams)
+  | None => None
+  }
+}
+
+@live
+let targetToPath = (target: target): string =>
+  makeLink(~byStatus=target.byStatus, ~statuses=?target.statuses, ~statusWithDefault=target.statusWithDefault, ~byValue=?target.byValue)
+
+@live
+let targetKey = targetToPath
+
+@live
+let targetRouteName = "Root__Todos__ByStatus"
+
+module Target = {
+  @live
+  type t =
+    | Self(target)
+
+  let fromMatchedRoute = (
+    matchedRoute: RelayRouter.Types.matchedRoute,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch matchedRoute.routeName {
+    | "Root__Todos__ByStatus" =>
+      targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Self(target)
+      )
+    | _ => None
+    }
+
+  let fromEntryWithQueryParams = (
+    entry: RelayRouter.Types.currentRouterEntry,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch entry.matchedRoutes->Array.toReversed->Array.get(0) {
+    | Some(matchedRoute) => fromMatchedRoute(matchedRoute, ~queryParams)
+    | None => None
+    }
+
+  let fromEntry = (entry: RelayRouter.Types.currentRouterEntry): option<t> =>
+    fromEntryWithQueryParams(entry, ~queryParams=entry.queryParams)
+
+  let useCurrent = (): option<t> => {
+    let router = RelayRouter.useRouterContext()
+    let location = RelayRouter.Utils.useLocation()
+    let (entry, setEntry) = React.useState(() => router.get())
+
+    React.useEffect(() => {
+      let dispose = router.subscribe(nextEntry => setEntry(_ => nextEntry))
+      Some(dispose)
+    }, [router])
+
+    React.useMemo(() => {
+      let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+      fromEntryWithQueryParams(entry, ~queryParams)
+    }, (entry, location.search))
+  }
+
+  let fromLocation = (location: RelayRouter.History.location): option<t> =>
+    switch targetFromLocation(location) {
+    | Some(target) => Some(Self(target))
+    | None =>
+      None
+    }
+
+  let toPath = (target: t): string =>
+    switch target {
+    | Self(target) => targetToPath(target)
+    }
+
+  let key = toPath
+
+  let routeName = (target: t): string =>
+    switch target {
+    | Self(_) => "Root__Todos__ByStatus"
+    }
+
+}
+
+@live
 let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Option.isSome
 }

--- a/examples/client-rendering/src/routes/__generated__/Route__Root__Todos__Single_route.res
+++ b/examples/client-rendering/src/routes/__generated__/Route__Root__Todos__Single_route.res
@@ -173,6 +173,125 @@ let makeLinkFromQueryParams = (~todoId: string, queryParams: queryParams) => {
 let useMakeLinkWithPreservedPath = (): ((queryParams => queryParams) => string) => RelayRouter__Internal.useMakeLinkWithPreservedPath(~parseQueryParams=Internal.parseQueryParams, ~applyQueryParams)
 
 @live
+type target = {
+  todoId: string,
+  statuses: option<array<TodoStatus.t>>,
+  statusWithDefault: TodoStatus.t,
+  byValue: option<string>,
+  showMore: option<bool>,
+}
+
+@live
+let targetFromMatchedRoute = (
+  matchedRoute: RelayRouter.Types.matchedRoute,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<target> =>
+  switch matchedRoute.routeName {
+  | "Root__Todos__Single" =>
+    let decodedQueryParams = Internal.parseQueryParams(queryParams)
+    Some({
+      todoId: matchedRoute.pathParams->Dict.getUnsafe("todoId"),
+      statuses: decodedQueryParams.statuses,
+      statusWithDefault: decodedQueryParams.statusWithDefault,
+      byValue: decodedQueryParams.byValue,
+      showMore: decodedQueryParams.showMore,
+    })
+  | _ => None
+  }
+
+@live
+let targetFromLocation = (location: RelayRouter.History.location): option<target> => {
+  let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+  switch RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": true}, location.pathname) {
+  | Some({params}) =>
+    targetFromMatchedRoute({
+      routeName: "Root__Todos__Single",
+      routeKey: "",
+      pathParams: params,
+      slots: [],
+      outlet: None,
+    }, ~queryParams)
+  | None => None
+  }
+}
+
+@live
+let targetToPath = (target: target): string =>
+  makeLink(~todoId=target.todoId, ~statuses=?target.statuses, ~statusWithDefault=target.statusWithDefault, ~byValue=?target.byValue, ~showMore=?target.showMore)
+
+@live
+let targetKey = targetToPath
+
+@live
+let targetRouteName = "Root__Todos__Single"
+
+module Target = {
+  @live
+  type t =
+    | Self(target)
+
+  let fromMatchedRoute = (
+    matchedRoute: RelayRouter.Types.matchedRoute,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch matchedRoute.routeName {
+    | "Root__Todos__Single" =>
+      targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Self(target)
+      )
+    | _ => None
+    }
+
+  let fromEntryWithQueryParams = (
+    entry: RelayRouter.Types.currentRouterEntry,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch entry.matchedRoutes->Array.toReversed->Array.get(0) {
+    | Some(matchedRoute) => fromMatchedRoute(matchedRoute, ~queryParams)
+    | None => None
+    }
+
+  let fromEntry = (entry: RelayRouter.Types.currentRouterEntry): option<t> =>
+    fromEntryWithQueryParams(entry, ~queryParams=entry.queryParams)
+
+  let useCurrent = (): option<t> => {
+    let router = RelayRouter.useRouterContext()
+    let location = RelayRouter.Utils.useLocation()
+    let (entry, setEntry) = React.useState(() => router.get())
+
+    React.useEffect(() => {
+      let dispose = router.subscribe(nextEntry => setEntry(_ => nextEntry))
+      Some(dispose)
+    }, [router])
+
+    React.useMemo(() => {
+      let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+      fromEntryWithQueryParams(entry, ~queryParams)
+    }, (entry, location.search))
+  }
+
+  let fromLocation = (location: RelayRouter.History.location): option<t> =>
+    switch targetFromLocation(location) {
+    | Some(target) => Some(Self(target))
+    | None =>
+      None
+    }
+
+  let toPath = (target: t): string =>
+    switch target {
+    | Self(target) => targetToPath(target)
+    }
+
+  let key = toPath
+
+  let routeName = (target: t): string =>
+    switch target {
+    | Self(_) => "Root__Todos__Single"
+    }
+
+}
+
+@live
 let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Option.isSome
 }

--- a/examples/client-rendering/src/routes/__generated__/Route__Root__Todos_route.res
+++ b/examples/client-rendering/src/routes/__generated__/Route__Root__Todos_route.res
@@ -149,6 +149,176 @@ let makeLinkFromQueryParams = (queryParams: queryParams) => {
 let useMakeLinkWithPreservedPath = (): ((queryParams => queryParams) => string) => RelayRouter__Internal.useMakeLinkWithPreservedPath(~parseQueryParams=Internal.parseQueryParams, ~applyQueryParams)
 
 @live
+type target = {
+  statuses: option<array<TodoStatus.t>>,
+  statusWithDefault: TodoStatus.t,
+  byValue: option<string>,
+}
+
+@live
+let targetFromMatchedRoute = (
+  matchedRoute: RelayRouter.Types.matchedRoute,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<target> =>
+  switch matchedRoute.routeName {
+  | "Root__Todos" =>
+    let decodedQueryParams = Internal.parseQueryParams(queryParams)
+    Some({
+      statuses: decodedQueryParams.statuses,
+      statusWithDefault: decodedQueryParams.statusWithDefault,
+      byValue: decodedQueryParams.byValue,
+    })
+  | _ => None
+  }
+
+@live
+let targetFromLocation = (location: RelayRouter.History.location): option<target> => {
+  let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+  switch RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": true}, location.pathname) {
+  | Some({params}) =>
+    targetFromMatchedRoute({
+      routeName: "Root__Todos",
+      routeKey: "",
+      pathParams: params,
+      slots: [],
+      outlet: None,
+    }, ~queryParams)
+  | None => None
+  }
+}
+
+@live
+let targetToPath = (target: target): string =>
+  makeLink(~statuses=?target.statuses, ~statusWithDefault=target.statusWithDefault, ~byValue=?target.byValue)
+
+@live
+let targetKey = targetToPath
+
+@live
+let targetRouteName = "Root__Todos"
+
+module Target = {
+  @live
+  type t =
+    | Self(target)
+    | ByStatus(Route__Root__Todos__ByStatus_route.target)
+    | ByStatusDecoded(Route__Root__Todos__ByStatusDecoded_route.target)
+    | ByStatusDecoded__Child(Route__Root__Todos__ByStatusDecoded__Child_route.target)
+    | ByStatusDecodedExtra(Route__Root__Todos__ByStatusDecodedExtra_route.target)
+    | Single(Route__Root__Todos__Single_route.target)
+
+  let fromMatchedRoute = (
+    matchedRoute: RelayRouter.Types.matchedRoute,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch matchedRoute.routeName {
+    | "Root__Todos" =>
+      targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Self(target)
+      )
+    | "Root__Todos__ByStatus" =>
+      Route__Root__Todos__ByStatus_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        ByStatus(target)
+      )
+    | "Root__Todos__ByStatusDecoded" =>
+      Route__Root__Todos__ByStatusDecoded_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        ByStatusDecoded(target)
+      )
+    | "Root__Todos__ByStatusDecoded__Child" =>
+      Route__Root__Todos__ByStatusDecoded__Child_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        ByStatusDecoded__Child(target)
+      )
+    | "Root__Todos__ByStatusDecodedExtra" =>
+      Route__Root__Todos__ByStatusDecodedExtra_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        ByStatusDecodedExtra(target)
+      )
+    | "Root__Todos__Single" =>
+      Route__Root__Todos__Single_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Single(target)
+      )
+    | _ => None
+    }
+
+  let fromEntryWithQueryParams = (
+    entry: RelayRouter.Types.currentRouterEntry,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch entry.matchedRoutes->Array.toReversed->Array.get(0) {
+    | Some(matchedRoute) => fromMatchedRoute(matchedRoute, ~queryParams)
+    | None => None
+    }
+
+  let fromEntry = (entry: RelayRouter.Types.currentRouterEntry): option<t> =>
+    fromEntryWithQueryParams(entry, ~queryParams=entry.queryParams)
+
+  let useCurrent = (): option<t> => {
+    let router = RelayRouter.useRouterContext()
+    let location = RelayRouter.Utils.useLocation()
+    let (entry, setEntry) = React.useState(() => router.get())
+
+    React.useEffect(() => {
+      let dispose = router.subscribe(nextEntry => setEntry(_ => nextEntry))
+      Some(dispose)
+    }, [router])
+
+    React.useMemo(() => {
+      let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+      fromEntryWithQueryParams(entry, ~queryParams)
+    }, (entry, location.search))
+  }
+
+  let fromLocation = (location: RelayRouter.History.location): option<t> =>
+    switch targetFromLocation(location) {
+    | Some(target) => Some(Self(target))
+    | None =>
+      switch Route__Root__Todos__ByStatus_route.targetFromLocation(location) {
+      | Some(target) => Some(ByStatus(target))
+      | None =>
+        switch Route__Root__Todos__ByStatusDecoded_route.targetFromLocation(location) {
+        | Some(target) => Some(ByStatusDecoded(target))
+        | None =>
+          switch Route__Root__Todos__ByStatusDecoded__Child_route.targetFromLocation(location) {
+          | Some(target) => Some(ByStatusDecoded__Child(target))
+          | None =>
+            switch Route__Root__Todos__ByStatusDecodedExtra_route.targetFromLocation(location) {
+            | Some(target) => Some(ByStatusDecodedExtra(target))
+            | None =>
+              switch Route__Root__Todos__Single_route.targetFromLocation(location) {
+              | Some(target) => Some(Single(target))
+              | None =>
+                None
+              }
+            }
+          }
+        }
+      }
+    }
+
+  let toPath = (target: t): string =>
+    switch target {
+    | Self(target) => targetToPath(target)
+    | ByStatus(target) => Route__Root__Todos__ByStatus_route.targetToPath(target)
+    | ByStatusDecoded(target) => Route__Root__Todos__ByStatusDecoded_route.targetToPath(target)
+    | ByStatusDecoded__Child(target) => Route__Root__Todos__ByStatusDecoded__Child_route.targetToPath(target)
+    | ByStatusDecodedExtra(target) => Route__Root__Todos__ByStatusDecodedExtra_route.targetToPath(target)
+    | Single(target) => Route__Root__Todos__Single_route.targetToPath(target)
+    }
+
+  let key = toPath
+
+  let routeName = (target: t): string =>
+    switch target {
+    | Self(_) => "Root__Todos"
+    | ByStatus(_) => "Root__Todos__ByStatus"
+    | ByStatusDecoded(_) => "Root__Todos__ByStatusDecoded"
+    | ByStatusDecoded__Child(_) => "Root__Todos__ByStatusDecoded__Child"
+    | ByStatusDecodedExtra(_) => "Root__Todos__ByStatusDecodedExtra"
+    | Single(_) => "Root__Todos__Single"
+    }
+
+}
+
+@live
 let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Option.isSome
 }

--- a/examples/client-rendering/src/routes/__generated__/Route__Root_route.res
+++ b/examples/client-rendering/src/routes/__generated__/Route__Root_route.res
@@ -56,6 +56,211 @@ let makeLink = () => {
 }
 
 @live
+type target = unit
+
+@live
+let targetFromMatchedRoute = (
+  matchedRoute: RelayRouter.Types.matchedRoute,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<target> =>
+  switch matchedRoute.routeName {
+  | "Root" =>
+    ignore(queryParams)
+    Some(())
+  | _ => None
+  }
+
+@live
+let targetFromLocation = (location: RelayRouter.History.location): option<target> => {
+  let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+  switch RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": true}, location.pathname) {
+  | Some({params}) =>
+    targetFromMatchedRoute({
+      routeName: "Root",
+      routeKey: "",
+      pathParams: params,
+      slots: [],
+      outlet: None,
+    }, ~queryParams)
+  | None => None
+  }
+}
+
+@live
+let targetToPath = (_target: target): string => makeLink()
+
+@live
+let targetKey = targetToPath
+
+@live
+let targetRouteName = "Root"
+
+module Target = {
+  @live
+  type t =
+    | Self(target)
+    | Settings(Route__Root__Settings_route.target)
+    | Todos(Route__Root__Todos_route.target)
+    | Todos__ByStatus(Route__Root__Todos__ByStatus_route.target)
+    | Todos__ByStatusDecoded(Route__Root__Todos__ByStatusDecoded_route.target)
+    | Todos__ByStatusDecoded__Child(Route__Root__Todos__ByStatusDecoded__Child_route.target)
+    | Todos__ByStatusDecodedExtra(Route__Root__Todos__ByStatusDecodedExtra_route.target)
+    | Todos__Single(Route__Root__Todos__Single_route.target)
+    | PathParamsOnly(Route__Root__PathParamsOnly_route.target)
+    | Home(Route__Root__Home_route.target)
+
+  let fromMatchedRoute = (
+    matchedRoute: RelayRouter.Types.matchedRoute,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch matchedRoute.routeName {
+    | "Root" =>
+      targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Self(target)
+      )
+    | "Root__Settings" =>
+      Route__Root__Settings_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Settings(target)
+      )
+    | "Root__Todos" =>
+      Route__Root__Todos_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Todos(target)
+      )
+    | "Root__Todos__ByStatus" =>
+      Route__Root__Todos__ByStatus_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Todos__ByStatus(target)
+      )
+    | "Root__Todos__ByStatusDecoded" =>
+      Route__Root__Todos__ByStatusDecoded_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Todos__ByStatusDecoded(target)
+      )
+    | "Root__Todos__ByStatusDecoded__Child" =>
+      Route__Root__Todos__ByStatusDecoded__Child_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Todos__ByStatusDecoded__Child(target)
+      )
+    | "Root__Todos__ByStatusDecodedExtra" =>
+      Route__Root__Todos__ByStatusDecodedExtra_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Todos__ByStatusDecodedExtra(target)
+      )
+    | "Root__Todos__Single" =>
+      Route__Root__Todos__Single_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Todos__Single(target)
+      )
+    | "Root__PathParamsOnly" =>
+      Route__Root__PathParamsOnly_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        PathParamsOnly(target)
+      )
+    | "Root__Home" =>
+      Route__Root__Home_route.targetFromMatchedRoute(matchedRoute, ~queryParams)->Option.map(target =>
+        Home(target)
+      )
+    | _ => None
+    }
+
+  let fromEntryWithQueryParams = (
+    entry: RelayRouter.Types.currentRouterEntry,
+    ~queryParams: RelayRouter.Bindings.QueryParams.t,
+  ): option<t> =>
+    switch entry.matchedRoutes->Array.toReversed->Array.get(0) {
+    | Some(matchedRoute) => fromMatchedRoute(matchedRoute, ~queryParams)
+    | None => None
+    }
+
+  let fromEntry = (entry: RelayRouter.Types.currentRouterEntry): option<t> =>
+    fromEntryWithQueryParams(entry, ~queryParams=entry.queryParams)
+
+  let useCurrent = (): option<t> => {
+    let router = RelayRouter.useRouterContext()
+    let location = RelayRouter.Utils.useLocation()
+    let (entry, setEntry) = React.useState(() => router.get())
+
+    React.useEffect(() => {
+      let dispose = router.subscribe(nextEntry => setEntry(_ => nextEntry))
+      Some(dispose)
+    }, [router])
+
+    React.useMemo(() => {
+      let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+      fromEntryWithQueryParams(entry, ~queryParams)
+    }, (entry, location.search))
+  }
+
+  let fromLocation = (location: RelayRouter.History.location): option<t> =>
+    switch targetFromLocation(location) {
+    | Some(target) => Some(Self(target))
+    | None =>
+      switch Route__Root__Settings_route.targetFromLocation(location) {
+      | Some(target) => Some(Settings(target))
+      | None =>
+        switch Route__Root__Todos_route.targetFromLocation(location) {
+        | Some(target) => Some(Todos(target))
+        | None =>
+          switch Route__Root__Todos__ByStatus_route.targetFromLocation(location) {
+          | Some(target) => Some(Todos__ByStatus(target))
+          | None =>
+            switch Route__Root__Todos__ByStatusDecoded_route.targetFromLocation(location) {
+            | Some(target) => Some(Todos__ByStatusDecoded(target))
+            | None =>
+              switch Route__Root__Todos__ByStatusDecoded__Child_route.targetFromLocation(location) {
+              | Some(target) => Some(Todos__ByStatusDecoded__Child(target))
+              | None =>
+                switch Route__Root__Todos__ByStatusDecodedExtra_route.targetFromLocation(location) {
+                | Some(target) => Some(Todos__ByStatusDecodedExtra(target))
+                | None =>
+                  switch Route__Root__Todos__Single_route.targetFromLocation(location) {
+                  | Some(target) => Some(Todos__Single(target))
+                  | None =>
+                    switch Route__Root__PathParamsOnly_route.targetFromLocation(location) {
+                    | Some(target) => Some(PathParamsOnly(target))
+                    | None =>
+                      switch Route__Root__Home_route.targetFromLocation(location) {
+                      | Some(target) => Some(Home(target))
+                      | None =>
+                        None
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  let toPath = (target: t): string =>
+    switch target {
+    | Self(target) => targetToPath(target)
+    | Settings(target) => Route__Root__Settings_route.targetToPath(target)
+    | Todos(target) => Route__Root__Todos_route.targetToPath(target)
+    | Todos__ByStatus(target) => Route__Root__Todos__ByStatus_route.targetToPath(target)
+    | Todos__ByStatusDecoded(target) => Route__Root__Todos__ByStatusDecoded_route.targetToPath(target)
+    | Todos__ByStatusDecoded__Child(target) => Route__Root__Todos__ByStatusDecoded__Child_route.targetToPath(target)
+    | Todos__ByStatusDecodedExtra(target) => Route__Root__Todos__ByStatusDecodedExtra_route.targetToPath(target)
+    | Todos__Single(target) => Route__Root__Todos__Single_route.targetToPath(target)
+    | PathParamsOnly(target) => Route__Root__PathParamsOnly_route.targetToPath(target)
+    | Home(target) => Route__Root__Home_route.targetToPath(target)
+    }
+
+  let key = toPath
+
+  let routeName = (target: t): string =>
+    switch target {
+    | Self(_) => "Root"
+    | Settings(_) => "Root__Settings"
+    | Todos(_) => "Root__Todos"
+    | Todos__ByStatus(_) => "Root__Todos__ByStatus"
+    | Todos__ByStatusDecoded(_) => "Root__Todos__ByStatusDecoded"
+    | Todos__ByStatusDecoded__Child(_) => "Root__Todos__ByStatusDecoded__Child"
+    | Todos__ByStatusDecodedExtra(_) => "Root__Todos__ByStatusDecodedExtra"
+    | Todos__Single(_) => "Root__Todos__Single"
+    | PathParamsOnly(_) => "Root__PathParamsOnly"
+    | Home(_) => "Root__Home"
+    }
+
+}
+
+@live
 let isRouteActive = (~exact: bool=false, {pathname}: RelayRouter.History.location): bool => {
   RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": exact}, pathname)->Option.isSome
 }

--- a/examples/client-rendering/src/routes/__generated__/Routes.res
+++ b/examples/client-rendering/src/routes/__generated__/Routes.res
@@ -4,41 +4,51 @@
 /** [See route renderer](./Root_route_renderer.res)*/
 module Root = {
   module Route = Route__Root_route
+  module Target = Route__Root_route.Target
   module Slots = Route__Root_route.Slots
   /** [See route renderer](./Root__Settings_route_renderer.res)*/
   module Settings = {
     module Route = Route__Root__Settings_route
+    module Target = Route__Root__Settings_route.Target
   }
   /** [See route renderer](./Root__Todos_route_renderer.res)*/
   module Todos = {
     module Route = Route__Root__Todos_route
+    module Target = Route__Root__Todos_route.Target
     /** [See route renderer](./Root__Todos__ByStatus_route_renderer.res)*/
     module ByStatus = {
       module Route = Route__Root__Todos__ByStatus_route
+      module Target = Route__Root__Todos__ByStatus_route.Target
     }
     /** [See route renderer](./Root__Todos__ByStatusDecoded_route_renderer.res)*/
     module ByStatusDecoded = {
       module Route = Route__Root__Todos__ByStatusDecoded_route
+      module Target = Route__Root__Todos__ByStatusDecoded_route.Target
       /** [See route renderer](./Root__Todos__ByStatusDecoded__Child_route_renderer.res)*/
       module Child = {
         module Route = Route__Root__Todos__ByStatusDecoded__Child_route
+        module Target = Route__Root__Todos__ByStatusDecoded__Child_route.Target
       }
     }
     /** [See route renderer](./Root__Todos__ByStatusDecodedExtra_route_renderer.res)*/
     module ByStatusDecodedExtra = {
       module Route = Route__Root__Todos__ByStatusDecodedExtra_route
+      module Target = Route__Root__Todos__ByStatusDecodedExtra_route.Target
     }
     /** [See route renderer](./Root__Todos__Single_route_renderer.res)*/
     module Single = {
       module Route = Route__Root__Todos__Single_route
+      module Target = Route__Root__Todos__Single_route.Target
     }
   }
   /** [See route renderer](./Root__PathParamsOnly_route_renderer.res)*/
   module PathParamsOnly = {
     module Route = Route__Root__PathParamsOnly_route
+    module Target = Route__Root__PathParamsOnly_route.Target
   }
   /** [See route renderer](./Root__Home_route_renderer.res)*/
   module Home = {
     module Route = Route__Root__Home_route
+    module Target = Route__Root__Home_route.Target
   }
 }

--- a/examples/client-rendering/test/UrlEncodingDecoding.test.res
+++ b/examples/client-rendering/test/UrlEncodingDecoding.test.res
@@ -4,6 +4,8 @@ open TestingLibraryReact
 
 let makeRouteEntry = (location): RelayRouter.Types.currentRouterEntry => {
   location,
+  queryParams: RelayRouter.Bindings.QueryParams.parse(location.search),
+  matchedRoutes: [],
   preparedMatches: [],
   primaryMatches: [],
   slotContents: dict{},
@@ -127,6 +129,62 @@ describe("parsing", () => {
     unsubscribeLocation()
     unsubscribeRoute()
     cleanup()
+  })
+
+  test("router entry exposes matched routes and generated targets can read them", _t => {
+    let routes = RouteDeclarations.make()
+    let (cleanup, routerContext) = RelayRouter.Router.make(
+      ~routes,
+      ~environment=RelayEnv.environment,
+      ~routerEnvironment=RelayRouter.RouterEnvironment.makeServerEnvironment(
+        ~initialUrl="/todos/extra/completed?byValue=from-url",
+      ),
+      ~preloadAsset=RelayRouter.AssetPreloader.makeClientAssetPreloader(RelayEnv.preparedAssetsMap),
+    )
+    let entry = routerContext.get()
+
+    switch entry.matchedRoutes->Array.get(entry.matchedRoutes->Array.length - 1) {
+    | Some(matchedRoute) =>
+      expect(matchedRoute.routeName)->Expect.toBe("Root__Todos__ByStatusDecodedExtra")
+      expect(matchedRoute.pathParams->Dict.get("byStatusDecoded"))->Expect.toBe(Some("completed"))
+    | None => expect("missing matched route")->Expect.toBe("matched route")
+    }
+
+    switch entry->Routes.Root.Target.fromEntry {
+    | Some(Routes.Root.Target.Todos__ByStatusDecodedExtra(target)) =>
+      let rootTarget = Routes.Root.Target.Todos__ByStatusDecodedExtra(target)
+      expect((target.byStatusDecoded :> string))->Expect.toBe("completed")
+      expect(target.byValue)->Expect.toBe(Some("from-url"))
+      expect(rootTarget->Routes.Root.Target.routeName)->Expect.toBe(
+        "Root__Todos__ByStatusDecodedExtra",
+      )
+      expect(rootTarget->Routes.Root.Target.toPath)->Expect.toBe(
+        "/todos/extra/completed?byValue=from-url",
+      )
+    | Some(_) => expect("unexpected route target")->Expect.toBe("todos extra target")
+    | None => expect("missing route target")->Expect.toBe("todos extra target")
+    }
+
+    cleanup()
+  })
+
+  test("generated targets can be built by parsing a location", _t => {
+    let history = RelayRouter.History.createMemoryHistory(
+      ~options={"initialEntries": ["/todos/extra/not-completed?byValue=from-location"]},
+    )
+    let location = history->RelayRouter.History.getLocation
+
+    switch location->Routes.Root.Target.fromLocation {
+    | Some(Routes.Root.Target.Todos__ByStatusDecodedExtra(target)) =>
+      let rootTarget = Routes.Root.Target.Todos__ByStatusDecodedExtra(target)
+      expect((target.byStatusDecoded :> string))->Expect.toBe("not-completed")
+      expect(target.byValue)->Expect.toBe(Some("from-location"))
+      expect(rootTarget->Routes.Root.Target.key)->Expect.toBe(
+        "/todos/extra/not-completed?byValue=from-location",
+      )
+    | Some(_) => expect("unexpected route target")->Expect.toBe("todos extra target")
+    | None => expect("missing route target")->Expect.toBe("todos extra target")
+    }
   })
 
   test("parseRoute correctly decode query params", _t => {

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res
@@ -3,6 +3,17 @@ module Utils = RescriptRelayRouterCli__Utils
 
 let wrapInOpt = str => `option<${str}>`
 
+let indentLines = str =>
+  str
+  ->String.split("\n")
+  ->Array.map(line =>
+    switch line == "" {
+    | true => line
+    | false => `  ${line}`
+    }
+  )
+  ->Array.join("\n")
+
 // Param and query param names might collide with eachother, as well as with
 // "builtins" we use, like "environment". This helps handle that by checking for
 // collisions, letting us refer to safe names where needed.
@@ -40,6 +51,175 @@ module SafeParam = {
     switch key {
     | Actual(key) | CollisionPrevented({realKey: key}) => key
     }
+}
+
+type targetFieldSource =
+  | TargetPathParam(printablePathParam)
+  | TargetQueryParam(queryParam)
+
+type targetField = {
+  fieldName: string,
+  originalName: string,
+  typ: string,
+  source: targetFieldSource,
+}
+
+let getTargetFields = (route: printableRoute): array<targetField> => {
+  let fields = []
+
+  route.params->Array.forEach(param => {
+    let fieldName = Utils.printablePathParamToParamName(param)
+    fields->Array.push({
+      fieldName,
+      originalName: fieldName,
+      typ: Utils.printablePathParamToTypeStr(param),
+      source: TargetPathParam(param),
+    })
+  })
+
+  route.queryParams
+  ->Dict.toArray
+  ->Array.forEach(((queryParamName, queryParam)) => {
+    let safeParam = QueryParam(queryParamName)->SafeParam.makeSafeParamName(~params=route.params)
+    let queryParamType = queryParam->Utils.QueryParams.toTypeStr
+
+    fields->Array.push({
+      fieldName: safeParam->SafeParam.getSafeKey,
+      originalName: queryParamName,
+      typ: switch queryParam->Utils.queryParamIsOptional {
+      | true => queryParamType->wrapInOpt
+      | false => queryParamType
+      },
+      source: TargetQueryParam(queryParam),
+    })
+  })
+
+  fields
+}
+
+let getTargetTypeDefinition = (route: printableRoute) => {
+  switch route->getTargetFields {
+  | [] => "@live\ntype target = unit\n"
+  | fields =>
+    `@live
+type target = {
+${fields->Array.map(field => `  ${field.fieldName}: ${field.typ},`)->Array.join("\n")}
+}
+`
+  }
+}
+
+let getPathParamTargetValue = (param: printablePathParam, ~paramName) => {
+  let rawValue = `matchedRoute.pathParams->Dict.getUnsafe("${paramName}")`
+  switch param {
+  | PrintableRegularPathParam({text, pathToCustomModuleWithTypeT}) =>
+    `${rawValue}->((${text}RawAsString: string) => (${text}RawAsString :> ${pathToCustomModuleWithTypeT}))`
+  | PrintablePathParamWithMatchBranches(_) => `${rawValue}->Obj.magic`
+  | PrintableRegularPathParam(_) => rawValue
+  }
+}
+
+let getTargetRecordLiteral = (route: printableRoute, ~pathParamsSource) => {
+  let fields = route->getTargetFields
+
+  switch fields {
+  | [] => "()"
+  | fields =>
+    `{
+${fields
+      ->Array.map(field => {
+        let value = switch field.source {
+        | TargetPathParam(param) =>
+          switch pathParamsSource {
+          | "matchedRoute" => getPathParamTargetValue(param, ~paramName=field.originalName)
+          | pathParamsSource => `${pathParamsSource}.${field.fieldName}`
+          }
+        | TargetQueryParam(_) => `decodedQueryParams.${field.originalName}`
+        }
+        `  ${field.fieldName}: ${value},`
+      })
+      ->Array.join("\n")}
+}`
+  }
+}
+
+let getMakeLinkTargetArguments = (route: printableRoute) => {
+  route
+  ->getTargetFields
+  ->Array.map(field =>
+    switch field.source {
+    | TargetPathParam(_) => `~${field.fieldName}=target.${field.fieldName}`
+    | TargetQueryParam(queryParam) =>
+      switch queryParam->Utils.queryParamIsOptional {
+      | true => `~${field.fieldName}=?target.${field.fieldName}`
+      | false => `~${field.fieldName}=target.${field.fieldName}`
+      }
+    }
+  )
+  ->Array.join(", ")
+}
+
+let getTargetAssets = (route: printableRoute) => {
+  let fullRouteName = route.name->RouteName.getFullRouteName
+  let hasQueryParams = route.queryParams->Dict.keysToArray->Array.length > 0
+  let targetRecordLiteral = route->getTargetRecordLiteral(~pathParamsSource="matchedRoute")
+  let targetFromMatchedRoute = `@live
+let targetFromMatchedRoute = (
+  matchedRoute: RelayRouter.Types.matchedRoute,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<target> =>
+  switch matchedRoute.routeName {
+  | "${fullRouteName}" =>
+${switch hasQueryParams {
+    | true => "    let decodedQueryParams = Internal.parseQueryParams(queryParams)\n"
+    | false => "    ignore(queryParams)\n"
+    }}    Some(${targetRecordLiteral
+    ->String.split("\n")
+    ->Array.mapWithIndex((line, index) =>
+      switch index {
+      | 0 => line
+      | _ => `    ${line}`
+      }
+    )
+    ->Array.join("\n")})
+  | _ => None
+  }
+`
+
+  let targetToPath = switch route->getTargetFields {
+  | [] => `@live\nlet targetToPath = (_target: target): string => makeLink()\n`
+  | _ =>
+    `@live
+let targetToPath = (target: target): string =>
+  makeLink(${route->getMakeLinkTargetArguments})
+`
+  }
+
+  `${route->getTargetTypeDefinition}
+${targetFromMatchedRoute}
+@live
+let targetFromLocation = (location: RelayRouter.History.location): option<target> => {
+  let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+  switch RelayRouter.Internal.matchPathWithOptions({"path": routePattern, "end": true}, location.pathname) {
+  | Some({params}) =>
+    targetFromMatchedRoute({
+      routeName: "${fullRouteName}",
+      routeKey: "",
+      pathParams: params,
+      slots: [],
+      outlet: None,
+    }, ~queryParams)
+  | None => None
+  }
+}
+
+${targetToPath}
+@live
+let targetKey = targetToPath
+
+@live
+let targetRouteName = "${fullRouteName}"
+`
 }
 
 let getRouteMakerAndAssets = (route: printableRoute) => {
@@ -843,4 +1023,157 @@ let parseRoute: (
   } else {
     ""
   }
+}
+
+let rec flattenRoutes = (route: printableRoute): array<printableRoute> => {
+  let routes = [route]
+  route.children->Array.forEach(child => {
+    child->flattenRoutes->Array.forEach(route => routes->Array.push(route))
+  })
+  routes
+}
+
+let targetVariantName = (~root: printableRoute, route: printableRoute) => {
+  let rootName = root.name->RouteName.getFullRouteName
+  let routeName = route.name->RouteName.getFullRouteName
+
+  switch routeName == rootName {
+  | true => "Self"
+  | false => routeName->String.replace(`${rootName}__`, "")
+  }
+}
+
+let targetRouteAccessor = (~root: printableRoute, route: printableRoute, ~localName) => {
+  let rootName = root.name->RouteName.getFullRouteName
+  let routeName = route.name->RouteName.getFullRouteName
+
+  switch routeName == rootName {
+  | true => localName
+  | false => `${route.name->RouteName.toGeneratedRouteModuleName}.${localName}`
+  }
+}
+
+let rec getTargetFromLocationChain = (
+  routes: list<printableRoute>,
+  ~root: printableRoute,
+  ~indentation,
+) => {
+  let indentationStr = "  "->String.repeat(indentation)
+  switch routes {
+  | list{} => `${indentationStr}None`
+  | list{route, ...rest} =>
+    let variantName = route->targetVariantName(~root)
+    let targetFromLocation = route->targetRouteAccessor(~root, ~localName="targetFromLocation")
+    `${indentationStr}switch ${targetFromLocation}(location) {
+${indentationStr}| Some(target) => Some(${variantName}(target))
+${indentationStr}| None =>
+${rest->getTargetFromLocationChain(~root, ~indentation=indentation + 1)}
+${indentationStr}}`
+  }
+}
+
+let getTargetModule = (root: printableRoute) => {
+  let routes = root->flattenRoutes
+  let variantLines =
+    routes
+    ->Array.map(route => {
+      let variantName = route->targetVariantName(~root)
+      let targetType = route->targetRouteAccessor(~root, ~localName="target")
+      `  | ${variantName}(${targetType})`
+    })
+    ->Array.join("\n")
+
+  let fromMatchedRouteCases =
+    routes
+    ->Array.map(route => {
+      let variantName = route->targetVariantName(~root)
+      let routeName = route.name->RouteName.getFullRouteName
+      let targetFromMatchedRoute =
+        route->targetRouteAccessor(~root, ~localName="targetFromMatchedRoute")
+      `  | "${routeName}" =>
+    ${targetFromMatchedRoute}(matchedRoute, ~queryParams)->Option.map(target =>
+      ${variantName}(target)
+    )`
+    })
+    ->Array.join("\n")
+
+  let toPathCases =
+    routes
+    ->Array.map(route => {
+      let variantName = route->targetVariantName(~root)
+      let targetToPath = route->targetRouteAccessor(~root, ~localName="targetToPath")
+      `  | ${variantName}(target) => ${targetToPath}(target)`
+    })
+    ->Array.join("\n")
+
+  let routeNameCases =
+    routes
+    ->Array.map(route => {
+      let variantName = route->targetVariantName(~root)
+      let routeName = route.name->RouteName.getFullRouteName
+      `  | ${variantName}(_) => "${routeName}"`
+    })
+    ->Array.join("\n")
+
+  let body = `@live
+type t =
+${variantLines}
+
+let fromMatchedRoute = (
+  matchedRoute: RelayRouter.Types.matchedRoute,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<t> =>
+  switch matchedRoute.routeName {
+${fromMatchedRouteCases}
+  | _ => None
+  }
+
+let fromEntryWithQueryParams = (
+  entry: RelayRouter.Types.currentRouterEntry,
+  ~queryParams: RelayRouter.Bindings.QueryParams.t,
+): option<t> =>
+  switch entry.matchedRoutes->Array.toReversed->Array.get(0) {
+  | Some(matchedRoute) => fromMatchedRoute(matchedRoute, ~queryParams)
+  | None => None
+  }
+
+let fromEntry = (entry: RelayRouter.Types.currentRouterEntry): option<t> =>
+  fromEntryWithQueryParams(entry, ~queryParams=entry.queryParams)
+
+let useCurrent = (): option<t> => {
+  let router = RelayRouter.useRouterContext()
+  let location = RelayRouter.Utils.useLocation()
+  let (entry, setEntry) = React.useState(() => router.get())
+
+  React.useEffect(() => {
+    let dispose = router.subscribe(nextEntry => setEntry(_ => nextEntry))
+    Some(dispose)
+  }, [router])
+
+  React.useMemo(() => {
+    let queryParams = RelayRouter.Bindings.QueryParams.parse(location.search)
+    fromEntryWithQueryParams(entry, ~queryParams)
+  }, (entry, location.search))
+}
+
+let fromLocation = (location: RelayRouter.History.location): option<t> =>
+${routes->List.fromArray->getTargetFromLocationChain(~root, ~indentation=1)}
+
+let toPath = (target: t): string =>
+  switch target {
+${toPathCases}
+  }
+
+let key = toPath
+
+let routeName = (target: t): string =>
+  switch target {
+${routeNameCases}
+  }
+`
+
+  `module Target = {
+${body->indentLines}
+}
+`
 }

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Commands.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Commands.res
@@ -117,6 +117,8 @@ let generateRoutes = (~scaffoldAfter, ~deleteRemoved, ~config) => {
         Codegen.getPrepareTypeDefinitions(route) ++ "}",
         Codegen.getQueryParamAssets(route),
         Codegen.getRouteMakerAndAssets(route),
+        Codegen.getTargetAssets(route),
+        Codegen.getTargetModule(route),
         Codegen.getActiveRouteAssets(route),
         Codegen.getSlotAssets(route),
         Codegen.getUsePathParamsHook(route),

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Utils.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Utils.res
@@ -275,12 +275,16 @@ let rec printNestedRouteModules = (route: printableRoute, ~indentation): string 
   let indentationStr = "  "->String.repeat(indentation)
   let innerIndentationStr = "  "->String.repeat(indentation + 1)
   let routeLine = `${innerIndentationStr}module Route = ${route.name->RouteName.toGeneratedRouteModuleName}`
+  let targetLine = `${innerIndentationStr}module Target = ${route.name->RouteName.toGeneratedRouteModuleName}.Target`
   let slotsLine = switch route.slots {
   | [] => ""
   | _slots =>
     `${innerIndentationStr}module Slots = ${route.name->RouteName.toGeneratedRouteModuleName}.Slots`
   }
-  let moduleLines = [routeLine, slotsLine]->Array.filter(line => line != "")->Array.join("\n")
+  let moduleLines =
+    [routeLine, targetLine, slotsLine]
+    ->Array.filter(line => line != "")
+    ->Array.join("\n")
   let childModules =
     route.children
     ->Array.map(route => route->printNestedRouteModules(~indentation=indentation + 1))

--- a/packages/rescript-relay-router/src/RelayRouter.res
+++ b/packages/rescript-relay-router/src/RelayRouter.res
@@ -83,9 +83,14 @@ module Router = {
 
     let preparedMatches =
       initialMatches->prepareMatches(~environment, ~queryParams=initialQueryParams, ~location)
+    let initialMatchedRoutes = initialMatches->RelayRouter__MatchedRoutes.make(preparedMatches)
 
     let currentEntry = ref(
-      preparedMatches->RelayRouter__RouteSlots.routeSetFromPreparedMatches(~location),
+      preparedMatches->RelayRouter__RouteSlots.routeSetFromPreparedMatches(
+        ~location,
+        ~queryParams=initialQueryParams,
+        ~matchedRoutes=initialMatchedRoutes,
+      ),
     )
     let currentLocation = ref(location)
 
@@ -118,8 +123,13 @@ module Router = {
 
         let matches = matchLocation(location)->Option.getOr([])
         let preparedMatches = matches->prepareMatches(~environment, ~queryParams, ~location)
+        let matchedRoutes = matches->RelayRouter__MatchedRoutes.make(preparedMatches)
         currentEntry.contents =
-          preparedMatches->RelayRouter__RouteSlots.routeSetFromPreparedMatches(~location)
+          preparedMatches->RelayRouter__RouteSlots.routeSetFromPreparedMatches(
+            ~location,
+            ~queryParams,
+            ~matchedRoutes,
+          )
 
         // Notify anyone interested about routes that will now unmount.
         currentMatches->Array.forEach(({routeKey}) => {

--- a/packages/rescript-relay-router/src/RelayRouter__MatchedRoutes.res
+++ b/packages/rescript-relay-router/src/RelayRouter__MatchedRoutes.res
@@ -1,0 +1,15 @@
+open RelayRouter__Types
+
+let make = (matches: array<routeMatch>, preparedMatches: array<preparedMatch>): array<
+  matchedRoute,
+> =>
+  matches->Array.mapWithIndex((match, index) => {
+    let preparedMatch = preparedMatches->Array.get(index)
+    {
+      routeKey: preparedMatch->Option.map(match => match.routeKey)->Option.getOr(match.route.name),
+      routeName: match.route.name,
+      pathParams: match.params,
+      slots: match.route.slots,
+      outlet: match.route.outlet,
+    }
+  })

--- a/packages/rescript-relay-router/src/RelayRouter__RouteSlots.res
+++ b/packages/rescript-relay-router/src/RelayRouter__RouteSlots.res
@@ -115,6 +115,8 @@ let splitPreparedMatches = (preparedMatches: array<preparedMatch>): (
 let routeSetFromPreparedMatches = (
   preparedMatches: array<preparedMatch>,
   ~location,
+  ~queryParams,
+  ~matchedRoutes,
 ): currentRouterEntry => {
   let (primaryMatches, slotBranch) = preparedMatches->splitPreparedMatches
 
@@ -131,6 +133,8 @@ let routeSetFromPreparedMatches = (
 
   {
     location,
+    queryParams,
+    matchedRoutes,
     preparedMatches,
     primaryMatches,
     slotContents,

--- a/packages/rescript-relay-router/src/RelayRouter__Types.res
+++ b/packages/rescript-relay-router/src/RelayRouter__Types.res
@@ -59,8 +59,18 @@ type preparedMatch = {
   render: renderRouteFn,
 }
 
+type matchedRoute = {
+  routeKey: string,
+  routeName: string,
+  pathParams: dict<string>,
+  slots: array<string>,
+  outlet: option<string>,
+}
+
 type currentRouterEntry = {
   location: RelayRouter__History.location,
+  queryParams: QueryParams.t,
+  matchedRoutes: array<matchedRoute>,
   preparedMatches: array<preparedMatch>,
   primaryMatches: array<preparedMatch>,
   slotContents: dict<React.element>,

--- a/packages/rescript-relay-router/test/MatchedRoutes.test.res
+++ b/packages/rescript-relay-router/test/MatchedRoutes.test.res
@@ -1,0 +1,91 @@
+open RescriptRelayRouterTestUtils.Vitest
+
+let render = (~childRoutes as _) => React.null
+
+let makeRoute = (~name, ~slots=[], ~outlet=?, ()): RelayRouter.Types.route => {
+  path: "",
+  name,
+  slots,
+  outlet,
+  loadRouteRenderer: () => Promise.resolve(),
+  preloadCode: (~environment as _, ~pathParams as _, ~queryParams as _, ~location as _) =>
+    Promise.resolve([]),
+  prepare: (
+    ~environment as _,
+    ~pathParams as _,
+    ~queryParams as _,
+    ~location as _,
+    ~intent as _,
+  ) => {
+    routeKey: `${name}:prepared`,
+    render,
+  },
+  children: [],
+}
+
+describe("matched route snapshots", () => {
+  test("copies route identity, prepared route key, params, slots, and outlet", _t => {
+    let shellRoute = makeRoute(~name="Shell", ~slots=["Overlay"], ())
+    let threadRoute = makeRoute(~name="Shell__Workspace__Thread", ~outlet="Overlay", ())
+    let matches: array<RelayRouter.Types.routeMatch> = [
+      {
+        route: shellRoute,
+        params: dict{
+          "workspaceSlug": "default",
+        },
+      },
+      {
+        route: threadRoute,
+        params: dict{
+          "workspaceSlug": "default",
+          "channelSlug": "general",
+          "threadId": "t1",
+        },
+      },
+    ]
+    let preparedMatches: array<RelayRouter.Types.preparedMatch> = [
+      {
+        routeKey: "Shell:default",
+        routeName: "Shell",
+        slots: ["Overlay"],
+        outlet: None,
+        render,
+      },
+      {
+        routeKey: "Thread:default:general:t1",
+        routeName: "Shell__Workspace__Thread",
+        slots: [],
+        outlet: Some("Overlay"),
+        render,
+      },
+    ]
+
+    let matchedRoutes = matches->RelayRouter__MatchedRoutes.make(preparedMatches)
+    expect(matchedRoutes->Array.length)->Expect.toBe(2)
+
+    switch matchedRoutes->Array.get(1) {
+    | Some(matchedRoute) =>
+      expect(matchedRoute.routeName)->Expect.toBe("Shell__Workspace__Thread")
+      expect(matchedRoute.routeKey)->Expect.toBe("Thread:default:general:t1")
+      expect(matchedRoute.outlet)->Expect.toBe(Some("Overlay"))
+      expect(matchedRoute.pathParams->Dict.get("workspaceSlug"))->Expect.toBe(Some("default"))
+      expect(matchedRoute.pathParams->Dict.get("channelSlug"))->Expect.toBe(Some("general"))
+      expect(matchedRoute.pathParams->Dict.get("threadId"))->Expect.toBe(Some("t1"))
+    | None => expect("missing matched route")->Expect.toBe("matched route")
+    }
+  })
+
+  test("falls back to the route name when there is no prepared match", _t => {
+    let matches: array<RelayRouter.Types.routeMatch> = [
+      {
+        route: makeRoute(~name="Shell", ()),
+        params: dict{},
+      },
+    ]
+
+    switch matches->RelayRouter__MatchedRoutes.make([])->Array.get(0) {
+    | Some(matchedRoute) => expect(matchedRoute.routeKey)->Expect.toBe("Shell")
+    | None => expect("missing matched route")->Expect.toBe("matched route")
+    }
+  })
+})

--- a/packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res
+++ b/packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res
@@ -209,6 +209,73 @@ describe("Route slots", () => {
   })
 })
 
+describe("Route targets", () => {
+  test("generates typed route target helpers without putting logic in Routes.res", _t => {
+    withGeneratedRoutes(
+      `[
+        {
+          "name": "Shell",
+          "path": "/w/:workspaceSlug?paneConfig=string",
+          "children": [
+            {
+              "name": "Channel",
+              "path": "c/:channelSlug?filter=string",
+              "children": [
+                {
+                  "name": "Thread",
+                  "path": "thread/:threadId"
+                }
+              ]
+            }
+          ]
+        }
+      ]`,
+      (~generatedPath) => {
+        let routes = readGeneratedFile(~generatedPath, ~fileName="Routes.res")
+        let shellRoute = readGeneratedFile(~generatedPath, ~fileName="Route__Shell_route.res")
+        let channelRoute = readGeneratedFile(
+          ~generatedPath,
+          ~fileName="Route__Shell__Channel_route.res",
+        )
+        let threadRoute = readGeneratedFile(
+          ~generatedPath,
+          ~fileName="Route__Shell__Channel__Thread_route.res",
+        )
+
+        expect(routes)->Expect.String.toContain("module Target = Route__Shell_route.Target")
+        expect(routes)->Expect.String.toContain(
+          "module Target = Route__Shell__Channel__Thread_route.Target",
+        )
+        expect(routes->String.includes("let "))->Expect.toBe(false)
+
+        expect(shellRoute)->Expect.String.toContain("module Target = {")
+        expect(shellRoute)->Expect.String.toContain(
+          "| Channel__Thread(Route__Shell__Channel__Thread_route.target)",
+        )
+        expect(shellRoute)->Expect.String.toContain("let fromEntry =")
+        expect(shellRoute)->Expect.String.toContain("let useCurrent =")
+        expect(shellRoute)->Expect.String.toContain("let fromLocation =")
+        expect(shellRoute)->Expect.String.toContain("let toPath =")
+        expect(shellRoute)->Expect.String.toContain("let key = toPath")
+        expect(shellRoute)->Expect.String.toContain("let routeName =")
+
+        expect(channelRoute)->Expect.String.toContain("type target = {")
+        expect(channelRoute)->Expect.String.toContain("workspaceSlug: string,")
+        expect(channelRoute)->Expect.String.toContain("channelSlug: string,")
+        expect(channelRoute)->Expect.String.toContain("paneConfig: option<string>,")
+        expect(channelRoute)->Expect.String.toContain("filter: option<string>,")
+        expect(channelRoute)->Expect.String.toContain("let targetFromMatchedRoute =")
+        expect(channelRoute)->Expect.String.toContain("let targetToPath =")
+
+        expect(threadRoute)->Expect.String.toContain("threadId: string,")
+        expect(
+          threadRoute,
+        )->Expect.String.toContain(`makeLink(~threadId=target.threadId, ~workspaceSlug=target.workspaceSlug, ~channelSlug=target.channelSlug`)
+      },
+    )
+  })
+})
+
 describe("Route declarations", () => {
   test("generates standalone make modules only for top-level routes marked entrypoint", _t => {
     withGeneratedRoutes(

--- a/packages/rescript-relay-router/test/RouteSlots.test.res
+++ b/packages/rescript-relay-router/test/RouteSlots.test.res
@@ -13,7 +13,7 @@ let makePreparedMatch = (~routeName, ~slots=[], ~outlet=?, ()) => {
   render,
 }
 
-let routeNames = matches =>
+let routeNames = (matches: array<RelayRouter__Types.preparedMatch>) =>
   matches->Array.map(({RelayRouter__Types.routeName: routeName}) => routeName)
 
 let renderElement = text =>
@@ -34,6 +34,9 @@ let testLocation =
   RelayRouter.History.createMemoryHistory(
     ~options={"initialEntries": ["/preferences/account"]},
   )->RelayRouter.History.getLocation
+
+let testQueryParams = RelayRouter.Bindings.QueryParams.parse("")
+let testMatchedRoutes = []
 
 describe("RelayRouter__RouteSlots", () => {
   test("splits an outlet branch away from the primary route branch", _t => {
@@ -101,7 +104,11 @@ describe("RelayRouter__RouteSlots", () => {
     ]
 
     let routeEntry =
-      matches->RelayRouter__RouteSlots.routeSetFromPreparedMatches(~location=testLocation)
+      matches->RelayRouter__RouteSlots.routeSetFromPreparedMatches(
+        ~location=testLocation,
+        ~queryParams=testQueryParams,
+        ~matchedRoutes=testMatchedRoutes,
+      )
 
     expect(routeEntry.primaryMatches->routeNames)->Expect.toStrictEqual(["Shell"])
     expect(routeEntry.allMatches->routeNames)->Expect.toStrictEqual([
@@ -135,7 +142,11 @@ describe("RelayRouter__RouteSlots", () => {
     ]
 
     let routeEntry =
-      matches->RelayRouter__RouteSlots.routeSetFromPreparedMatches(~location=testLocation)
+      matches->RelayRouter__RouteSlots.routeSetFromPreparedMatches(
+        ~location=testLocation,
+        ~queryParams=testQueryParams,
+        ~matchedRoutes=testMatchedRoutes,
+      )
     let routerContext: RelayRouter.Types.routerContext = {
       preload: (~priority=?, _url) => ignore(priority),
       preloadCode: (~priority=?, _url) => ignore(priority),

--- a/plans/2026-05-19-typed-route-targets.md
+++ b/plans/2026-05-19-typed-route-targets.md
@@ -1,0 +1,54 @@
+# Typed Route Targets
+
+## Decision
+
+Codex implemented generated typed route targets for each generated route module and each route subtree.
+
+Each generated route file now exposes:
+
+- `type target`
+- `targetFromMatchedRoute`
+- `targetFromLocation`
+- `targetToPath`
+- `targetKey`
+- `targetRouteName`
+- `module Target`
+
+The nested `Target.t` variant represents the deepest active route in that subtree, with path params and query params decoded into the generated target record.
+
+## Why
+
+Kandan needs to turn the currently matched ShellV2 route into pane state without manually trying every generated `parseRoute` helper in app code. The router already has the matched route stack during navigation, so the generated API should expose that matched identity and decoded params directly.
+
+This keeps generated route helpers as the source of truth for route names, path params, query params, target serialization, and route keys.
+
+## Implementation Notes
+
+- `currentRouterEntry` now carries `queryParams` and a `matchedRoutes` snapshot.
+- `matchedRoute` stores route name, prepared route key, path params, slot names, and outlet.
+- `RelayRouter__MatchedRoutes.make` builds the snapshot from the router match stack and prepared matches.
+- Generated `Target.fromEntry` uses the entry snapshot and does not reparse routes.
+- Generated `Target.useCurrent` uses the current route entry plus the live location query string so shallow query navigations can update target query params.
+- Generated `Target.fromLocation` remains available for non-hook utility code, but the preferred runtime path is `fromEntry`/`useCurrent`.
+- Slots and outlets are metadata on the matched route; they do not change target identity. The target identity remains the leaf route inside the selected route subtree.
+
+## Verification
+
+Codex verified with:
+
+- `yarn rescript format`
+- `yarn build`
+- `yarn test`
+- `git diff --check`
+
+Added coverage:
+
+- package codegen tests for target module generation and `Routes.res` alias-only behavior
+- package unit tests for matched route snapshot construction
+- client-rendering tests for `Target.fromEntry`, `Target.fromLocation`, `Target.toPath`, `Target.key`, and `Target.routeName`
+
+## Non-Goals
+
+- No route metadata helpers such as `surface`, `kind`, or `isPaneTarget` yet.
+- No explicit multi-target URL model beyond the current route slot work.
+- No Kandan-specific pane or overlay API.


### PR DESCRIPTION
## Summary

- generate typed route target records and subtree Target variants
- expose matched route snapshots and query params on current router entries
- add package and sample coverage for fromEntry/fromLocation/toPath/key behavior

## Validation

- yarn rescript format
- yarn build
- yarn test
- git diff --check

## Notes

- Routes.res remains alias-only; generated target logic lives in route files.