### PR TITLE
[codex] Add root outlet URL resolution

### DIFF
--- a/.changeset/root-outlet-for-url.md
+++ b/.changeset/root-outlet-for-url.md
@@ -1,0 +1,5 @@
+---
+"rescript-relay-router": minor
+---
+
+Expose root-scoped route declaration helpers for resolving the typed effective outlet for a URL.

--- a/examples/client-rendering/src/routes/__generated__/RouteDeclarations.res
+++ b/examples/client-rendering/src/routes/__generated__/RouteDeclarations.res
@@ -4,11 +4,10 @@ external unsafe_toPrepareProps: 'any => prepareProps = "%identity"
 
 let loadedRouteRenderers: Map.t<string, loadedRouteRenderer> = Map.make()
 
-let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> => {
+let makeRootRoute = (~prepareDisposeTimeout=5 * 60 * 1000): RelayRouter.Types.route => {
   let {prepareRoute, getPrepared} = makePrepareAssets(~loadedRouteRenderers, ~prepareDisposeTimeout)
 
-  [
-      {
+  {
     let routeName = "Root"
     let loadRouteRenderer = () => (() => import(Root_route_renderer.renderer))->Obj.magic->doLoadRouteRenderer(~routeName, ~loadedRouteRenderers)
     let makePrepareProps = (.
@@ -31,6 +30,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
       name: routeName,
       slots: ["Overlay"],
       outlet: None,
+      effectiveOutlet: None,
       loadRouteRenderer,
       preloadCode: (
         ~environment: RescriptRelay.Environment.t,
@@ -96,6 +96,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
           name: routeName,
           slots: [],
           outlet: Some("Overlay"),
+          effectiveOutlet: Some("Overlay"),
           loadRouteRenderer,
           preloadCode: (
             ~environment: RescriptRelay.Environment.t,
@@ -165,6 +166,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
           name: routeName,
           slots: [],
           outlet: None,
+          effectiveOutlet: None,
           loadRouteRenderer,
           preloadCode: (
             ~environment: RescriptRelay.Environment.t,
@@ -234,6 +236,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
                 name: routeName,
                 slots: [],
                 outlet: None,
+                effectiveOutlet: None,
                 loadRouteRenderer,
                 preloadCode: (
                   ~environment: RescriptRelay.Environment.t,
@@ -306,6 +309,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
                 name: routeName,
                 slots: [],
                 outlet: None,
+                effectiveOutlet: None,
                 loadRouteRenderer,
                 preloadCode: (
                   ~environment: RescriptRelay.Environment.t,
@@ -375,6 +379,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
                         name: routeName,
                         slots: [],
                         outlet: None,
+                        effectiveOutlet: None,
                         loadRouteRenderer,
                         preloadCode: (
                           ~environment: RescriptRelay.Environment.t,
@@ -449,6 +454,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
                 name: routeName,
                 slots: [],
                 outlet: None,
+                effectiveOutlet: None,
                 loadRouteRenderer,
                 preloadCode: (
                   ~environment: RescriptRelay.Environment.t,
@@ -525,6 +531,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
                 name: routeName,
                 slots: [],
                 outlet: None,
+                effectiveOutlet: None,
                 loadRouteRenderer,
                 preloadCode: (
                   ~environment: RescriptRelay.Environment.t,
@@ -598,6 +605,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
           name: routeName,
           slots: [],
           outlet: None,
+          effectiveOutlet: None,
           loadRouteRenderer,
           preloadCode: (
             ~environment: RescriptRelay.Environment.t,
@@ -665,6 +673,7 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
           name: routeName,
           slots: [],
           outlet: None,
+          effectiveOutlet: None,
           loadRouteRenderer,
           preloadCode: (
             ~environment: RescriptRelay.Environment.t,
@@ -712,5 +721,26 @@ let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route
   ],
     }
   }
+}
+
+module Root = {
+  let routes = [makeRootRoute()]
+  let compiledRoutes = routes->RelayRouter.Internal.compileRoutes
+
+  type outlet = Overlay
+
+  let outletFromString: string => option<outlet> = outlet =>
+    switch outlet {
+    | "Overlay" => Some(Overlay)
+    | _ => None
+    }
+
+  let outletForUrl = url =>
+    RelayRouter.Internal.outletForUrl(compiledRoutes, url)->Option.flatMap(outletFromString)
+}
+
+let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> => {
+  [
+    makeRootRoute(~prepareDisposeTimeout)
   ]
 }

--- a/examples/client-rendering/src/routes/__generated__/RouteDeclarations.resi
+++ b/examples/client-rendering/src/routes/__generated__/RouteDeclarations.resi
@@ -1,1 +1,7 @@
+module Root: {
+  type outlet = Overlay
+
+  let outletForUrl: string => option<outlet>
+}
+
 let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>

--- a/examples/client-rendering/test/UrlEncodingDecoding.test.res
+++ b/examples/client-rendering/test/UrlEncodingDecoding.test.res
@@ -129,6 +129,14 @@ describe("parsing", () => {
     cleanup()
   })
 
+  test("outletForUrl returns the deepest match effective outlet", _t => {
+    expect(RouteDeclarations.Root.outletForUrl("/settings"))->Expect.toBe(
+      Some(RouteDeclarations.Root.Overlay),
+    )
+    expect(RouteDeclarations.Root.outletForUrl("/todos"))->Expect.toBe(None)
+    expect(RouteDeclarations.Root.outletForUrl("/not-found"))->Expect.toBe(None)
+  })
+
   test("parseRoute correctly decode query params", _t => {
     let queryParams =
       Routes.Root.Todos.Route.parseRoute(

--- a/packages/rescript-relay-router/README.md
+++ b/packages/rescript-relay-router/README.md
@@ -221,6 +221,17 @@ let renderer = Routes.Shell.Route.makeRenderer(
 
 Slot routes are still regular routes. They use their normal route renderer, `prepare`, `prepareCode`, query params, path params, links, and preloading. The `outlet` property only controls where the matched branch renders.
 
+The generated route declarations also expose a root-scoped `outletForUrl` helper:
+
+```rescript
+let renderTarget = switch RouteDeclarations.Shell.outletForUrl("/preferences/account") {
+| Some(Overlay) => "overlay"
+| Some(_) | None => "primary"
+}
+```
+
+`outletForUrl` uses the same route matcher as the runtime router and returns the deepest matched route's effective outlet as a typed outlet variant. Effective outlets are inherited by descendants, so a child route under an outlet route reports the same outlet even when the child does not repeat the `outlet` field.
+
 This initial implementation supports one active outlet branch per matched URL. A route tree may declare multiple slots, but a single URL match can only split once into the first descendant route that declares `outlet`.
 
 To create a "catch all" route, use the `*`, character as the route path. Typically used for the "not found" route. Example:

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Codegen.res
@@ -632,14 +632,17 @@ let addIndentation = (str, indentation) => {
   }
 }
 
-let rec getRouteDefinition = (route: printableRoute, ~indentation): string => {
+let rec getRouteDefinition = (route: printableRoute, ~indentation, ~inheritedOutlet=?): string => {
   let routeName = route.name->RouteName.getFullRouteName
+  let effectiveOutlet = route.outlet->Option.orElse(inheritedOutlet)
   let childrenDefinition = switch route.children {
   | [] => ""
   | children =>
     "\n" ++
     children
-    ->Array.map(route => getRouteDefinition(route, ~indentation=indentation + 1))
+    ->Array.map(route =>
+      getRouteDefinition(route, ~indentation=indentation + 1, ~inheritedOutlet=?effectiveOutlet)
+    )
     ->Array.join(",\n") ++ "\n"
   }
 
@@ -653,6 +656,10 @@ let rec getRouteDefinition = (route: printableRoute, ~indentation): string => {
     name: routeName,
     slots: [${route.slots->Array.map(slot => `"${slot}"`)->Array.join(", ")}],
     outlet: ${switch route.outlet {
+    | Some(outlet) => `Some("${outlet}")`
+    | None => "None"
+    }},
+    effectiveOutlet: ${switch effectiveOutlet {
     | Some(outlet) => `Some("${outlet}")`
     | None => "None"
     }},

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Commands.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Commands.res
@@ -137,25 +137,87 @@ let generateRoutes = (~scaffoldAfter, ~deleteRemoved, ~config) => {
   })
 
   // Write the full route declarations file
-  let entrypointRootModules =
-    routes
-    ->Array.filter(route => route.entrypoint)
-    ->Array.map(route => {
-      let moduleName = route.name->Types.RouteName.getRouteName
-      `module ${moduleName} = {
-  let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> => {
-    let {prepareRoute, getPrepared} = makePrepareAssets(~loadedRouteRenderers, ~prepareDisposeTimeout)
+  let rootRouteMakerName = (route: Types.printableRoute) =>
+    `make${route.name->Types.RouteName.getRouteName}Route`
+  let rec collectRouteOutlets = (route: Types.printableRoute, outlets) => {
+    switch route.outlet {
+    | Some(outlet) =>
+      switch outlets->Array.includes(outlet) {
+      | true => ()
+      | false => outlets->Array.push(outlet)
+      }
+    | None => ()
+    }
 
-    [
-      ${Codegen.getRouteDefinition(route, ~indentation=3)}
-    ]
+    route.children->Array.forEach(child => collectRouteOutlets(child, outlets))
   }
+  let routeOutlets = (route: Types.printableRoute) => {
+    let outlets = []
+    collectRouteOutlets(route, outlets)
+    outlets
+  }
+  let outletTypeDefinition = outlets =>
+    switch outlets {
+    | [] => "type outlet"
+    | outlets => `type outlet = ${outlets->Array.join(" | ")}`
+    }
+  let outletFromStringDefinition = outlets =>
+    switch outlets {
+    | [] => `let outletFromString: string => option<outlet> = _outlet => None`
+    | outlets =>
+      `let outletFromString: string => option<outlet> = outlet =>
+    switch outlet {
+    ${outlets->Array.map(outlet => `| "${outlet}" => Some(${outlet})`)->Array.join("\n    ")}
+    | _ => None
+    }`
+    }
+  let outletTypeSignature = outlets =>
+    switch outlets {
+    | [] => "type outlet"
+    | outlets => `type outlet = ${outlets->Array.join(" | ")}`
+    }
+  let rootRouteMakers =
+    routes
+    ->Array.map(route => {
+      let makeRouteName = route->rootRouteMakerName
+      `let ${makeRouteName} = (~prepareDisposeTimeout=5 * 60 * 1000): RelayRouter.Types.route => {
+  let {prepareRoute, getPrepared} = makePrepareAssets(~loadedRouteRenderers, ~prepareDisposeTimeout)
+
+${Codegen.getRouteDefinition(route, ~indentation=1)}
 }`
     })
     ->Array.join("\n\n")
-  let entrypointRootModulesSection = switch entrypointRootModules {
+
+  let rootModules =
+    routes
+    ->Array.map(route => {
+      let moduleName = route.name->Types.RouteName.getRouteName
+      let makeRouteName = route->rootRouteMakerName
+      let outlets = route->routeOutlets
+      let makeFunction = switch route.entrypoint {
+      | true =>
+        `
+  let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> => {
+    [${makeRouteName}(~prepareDisposeTimeout)]
+  }`
+      | false => ""
+      }
+      `module ${moduleName} = {
+  let routes = [${makeRouteName}()]
+  let compiledRoutes = routes->RelayRouter.Internal.compileRoutes
+
+  ${outlets->outletTypeDefinition}
+
+  ${outlets->outletFromStringDefinition}
+
+  let outletForUrl = url =>
+    RelayRouter.Internal.outletForUrl(compiledRoutes, url)->Option.flatMap(outletFromString)${makeFunction}
+}`
+    })
+    ->Array.join("\n\n")
+  let rootModulesSection = switch rootModules {
   | "" => ""
-  | entrypointRootModules => `${entrypointRootModules}\n\n`
+  | rootModules => `${rootModules}\n\n`
   }
 
   let fileContents = `open RelayRouter__Internal__DeclarationsSupport
@@ -164,12 +226,12 @@ external unsafe_toPrepareProps: 'any => prepareProps = "%identity"
 
 let loadedRouteRenderers: Map.t<string, loadedRouteRenderer> = Map.make()
 
-${entrypointRootModulesSection}let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> => {
-  let {prepareRoute, getPrepared} = makePrepareAssets(~loadedRouteRenderers, ~prepareDisposeTimeout)
+${rootRouteMakers}
 
+${rootModulesSection}let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> => {
   [
     ${routes
-    ->Array.map(route => Codegen.getRouteDefinition(route, ~indentation=1))
+    ->Array.map(route => `${route->rootRouteMakerName}(~prepareDisposeTimeout)`)
     ->Array.join(",\n")}
   ]
 }`
@@ -179,23 +241,31 @@ ${entrypointRootModulesSection}let make = (~prepareDisposeTimeout=5 * 60 * 1000)
   )
 
   // Write interface file as the signature of this will never change
-  let entrypointRootModuleSignatures =
+  let rootModuleSignatures =
     routes
-    ->Array.filter(route => route.entrypoint)
     ->Array.map(route => {
       let moduleName = route.name->Types.RouteName.getRouteName
-      `module ${moduleName}: {
+      let outlets = route->routeOutlets
+      let makeSignature = switch route.entrypoint {
+      | true => `
   let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>
+`
+      | false => ""
+      }
+      `module ${moduleName}: {
+  ${outlets->outletTypeSignature}
+
+  let outletForUrl: string => option<outlet>${makeSignature}
 }`
     })
     ->Array.join("\n\n")
-  let entrypointRootModuleSignaturesSection = switch entrypointRootModuleSignatures {
+  let rootModuleSignaturesSection = switch rootModuleSignatures {
   | "" => ""
-  | entrypointRootModuleSignatures => `${entrypointRootModuleSignatures}\n\n`
+  | rootModuleSignatures => `${rootModuleSignatures}\n\n`
   }
 
   Utils.pathInGeneratedFolder(~config, ~fileName="RouteDeclarations.resi")->Fs.writeFileIfChanged(
-    `${entrypointRootModuleSignaturesSection}let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>`,
+    `${rootModuleSignaturesSection}let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>`,
   )
 
   if scaffoldAfter {

--- a/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Parser.res
+++ b/packages/rescript-relay-router/cli/RescriptRelayRouterCli__Parser.res
@@ -901,11 +901,11 @@ module Decode = {
         let slots = slotsProp->validateSlots(~ctx)
         let outlet = outletProp->validateOutlet(~ctx, ~parentContext)
         let entrypoint = entrypointProp->Validators.validateEntrypoint(~ctx, ~parentContext)
-        switch (entrypoint, name) {
-        | (true, Some({name: "RelayRouter", loc})) =>
+        switch (parentContext.routeDepth, name) {
+        | (0, Some({name: "RelayRouter", loc})) =>
           ctx.addDecodeError(
             ~loc,
-            ~message=`"RelayRouter" cannot be used as an entrypoint route name because it would shadow the router runtime module in generated route declarations.`,
+            ~message=`"RelayRouter" cannot be used as a top-level route name because it would shadow the router runtime module in generated route declarations.`,
           )
         | _ => ()
         }

--- a/packages/rescript-relay-router/src/RelayRouter__Internal.res
+++ b/packages/rescript-relay-router/src/RelayRouter__Internal.res
@@ -116,6 +116,48 @@ external matchPath: (string, string) => option<pathMatch> = "matchPath"
 external matchPathWithOptions: ({"path": string, "end": bool}, string) => option<pathMatch> =
   "matchPath"
 
+type compiledRoutes
+
+@module("./vendor/react-router.js")
+external compileRoutes: array<route> => compiledRoutes = "compileRoutes"
+
+@module("./vendor/react-router.js") @return(nullable)
+external matchCompiledRoutes: (
+  compiledRoutes,
+  RelayRouter__History.location,
+) => option<array<routeMatch>> = "matchCompiledRoutes"
+
+let locationFromUrl = url => {
+  let urlObj = switch (url->String.startsWith("http://"), url->String.startsWith("https://")) {
+  | (true, _) | (_, true) => url
+  | (false, false) =>
+    switch url->String.startsWith("/") {
+    | true => `http://localhost${url}`
+    | false => `http://localhost/${url}`
+    }
+  }->RelayRouter__Bindings.URL.make
+
+  {
+    RelayRouter__History.pathname: urlObj->RelayRouter__Bindings.URL.getPathname,
+    search: urlObj->RelayRouter__Bindings.URL.getSearch->Option.getOr(""),
+    hash: urlObj->RelayRouter__Bindings.URL.getHash,
+    state: urlObj->RelayRouter__Bindings.URL.getState,
+    key: "-",
+  }
+}
+
+let outletForUrl = (compiledRoutes: compiledRoutes, url: string): option<string> => {
+  let location = url->locationFromUrl
+
+  switch matchCompiledRoutes(compiledRoutes, location) {
+  | Some(matches) =>
+    matches
+    ->Array.get(matches->Array.length - 1)
+    ->Option.flatMap(match => match.route.effectiveOutlet)
+  | None => None
+  }
+}
+
 type prepared
 external toObject: Type.Classify.object => {..} = "%identity"
 external objectToPreparedArrayUnsafe: Type.Classify.object => array<prepared> = "%identity"

--- a/packages/rescript-relay-router/src/RelayRouter__Internal.resi
+++ b/packages/rescript-relay-router/src/RelayRouter__Internal.resi
@@ -35,6 +35,13 @@ external matchPath: (string, string) => option<pathMatch> = "matchPath"
 external matchPathWithOptions: ({"path": string, "end": bool}, string) => option<pathMatch> =
   "matchPath"
 
+type compiledRoutes
+
+@module("./vendor/react-router.js")
+external compileRoutes: array<RelayRouter__Types.route> => compiledRoutes = "compileRoutes"
+
+let outletForUrl: (compiledRoutes, string) => option<string>
+
 type prepared
 
 module RouteKey: {

--- a/packages/rescript-relay-router/src/RelayRouter__Types.res
+++ b/packages/rescript-relay-router/src/RelayRouter__Types.res
@@ -29,6 +29,7 @@ type rec route = {
   name: string,
   slots: array<string>,
   outlet: option<string>,
+  effectiveOutlet: option<string>,
   loadRouteRenderer: unit => promise<unit>,
   preloadCode: (
     ~environment: RescriptRelay.Environment.t,

--- a/packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res
+++ b/packages/rescript-relay-router/test/RescriptRelayRouterCli.test.res
@@ -178,11 +178,11 @@ describe("Route slots", () => {
             {
               "name": "Preferences",
               "path": "preferences",
+              "outlet": "Overlay",
               "children": [
                 {
                   "name": "Account",
-                  "path": "account",
-                  "outlet": "Overlay"
+                  "path": "account"
                 }
               ]
             }
@@ -204,6 +204,30 @@ describe("Route slots", () => {
         )->Expect.String.toContain(`<RelayRouter.Slot routeName="Shell" slotName="Overlay" ?fallback />`)
         expect(routeDeclarations)->Expect.String.toContain(`slots: ["Overlay"]`)
         expect(routeDeclarations)->Expect.String.toContain(`outlet: Some("Overlay")`)
+        expect(routeDeclarations)->Expect.String.toContain(`effectiveOutlet: Some("Overlay")`)
+        expect(routeDeclarations)->Expect.String.toContain(`module Shell = {`)
+        expect(routeDeclarations)->Expect.String.toContain(`let routes = [makeShellRoute()]`)
+        expect(
+          routeDeclarations,
+        )->Expect.String.toContain(`let compiledRoutes = routes->RelayRouter.Internal.compileRoutes`)
+        expect(routeDeclarations)->Expect.String.toContain(`type outlet = Overlay`)
+        expect(
+          routeDeclarations,
+        )->Expect.String.toContain(`let outletFromString: string => option<outlet> = outlet =>`)
+        expect(routeDeclarations)->Expect.String.toContain(`| "Overlay" => Some(Overlay)`)
+        expect(
+          routeDeclarations,
+        )->Expect.String.toContain(`RelayRouter.Internal.outletForUrl(compiledRoutes, url)->Option.flatMap(outletFromString)`)
+        let accountRoute =
+          routeDeclarations->sliceBetween(
+            ~startMarker=`let routeName = "Shell__Preferences__Account"`,
+            ~endMarker="children: [],",
+          )
+        expect(
+          accountRoute,
+        )->Expect.String.toContain(`let routeName = "Shell__Preferences__Account"`)
+        expect(accountRoute)->Expect.String.toContain("outlet: None")
+        expect(accountRoute)->Expect.String.toContain(`effectiveOutlet: Some("Overlay")`)
       },
     )
   })
@@ -247,31 +271,50 @@ describe("Route declarations", () => {
           ~fileName="RouteDeclarations.resi",
         )
 
+        expect(routeDeclarations)->Expect.String.toContain("module Root = {")
         expect(routeDeclarations)->Expect.String.toContain("module Admin = {")
+        expect(routeDeclarations)->Expect.String.toContain("module Embedded = {")
+        let rootModule =
+          routeDeclarations->sliceBetween(
+            ~startMarker="module Root = {",
+            ~endMarker="\n\nmodule Admin = {",
+          )
+        let embeddedModule =
+          routeDeclarations->sliceBetween(
+            ~startMarker="module Embedded = {",
+            ~endMarker="\n\nlet make = (~prepareDisposeTimeout",
+          )
+
+        expect(rootModule)->Expect.String.toContain("let outletForUrl =")
+        expect(rootModule)->Expect.not->Expect.String.toContain("let make =")
+        expect(embeddedModule)->Expect.String.toContain("let outletForUrl =")
+        expect(embeddedModule)->Expect.not->Expect.String.toContain("let make =")
+
         expect(routeDeclarations)->Expect.String.toContain(
           "let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> =>",
         )
-        let adminModule =
+        let adminRouteMaker =
           routeDeclarations->sliceBetween(
-            ~startMarker="module Admin = {",
-            ~endMarker="\n\nlet make = (~prepareDisposeTimeout",
+            ~startMarker="let makeAdminRoute = ",
+            ~endMarker="\n\nlet makeEmbeddedRoute = ",
           )
-        expect(adminModule)->Expect.String.toContain(`let routeName = "Admin"`)
-        expect(adminModule)->Expect.String.toContain(`let routeName = "Admin__Users"`)
-        expect(adminModule)->Expect.not->Expect.String.toContain(`let routeName = "Root"`)
-        expect(adminModule)->Expect.not->Expect.String.toContain(`let routeName = "Embedded"`)
+        expect(adminRouteMaker)->Expect.String.toContain(`let routeName = "Admin"`)
+        expect(adminRouteMaker)->Expect.String.toContain(`let routeName = "Admin__Users"`)
+        expect(adminRouteMaker)->Expect.not->Expect.String.toContain(`let routeName = "Root"`)
+        expect(adminRouteMaker)->Expect.not->Expect.String.toContain(`let routeName = "Embedded"`)
         expect(
           routeDeclarations,
         )->Expect.String.toContain(`let make = (~prepareDisposeTimeout=5 * 60 * 1000): array<RelayRouter.Types.route> =>`)
-        expect(routeDeclarations)->Expect.not->Expect.String.toContain("module Root = {")
-        expect(routeDeclarations)->Expect.not->Expect.String.toContain("module Embedded = {")
-
+        expect(routeDeclarationsInterface)->Expect.String.toContain("module Root: {")
         expect(routeDeclarationsInterface)->Expect.String.toContain("module Admin: {")
+        expect(routeDeclarationsInterface)->Expect.String.toContain("module Embedded: {")
+        expect(routeDeclarationsInterface)->Expect.String.toContain("type outlet")
+        expect(routeDeclarationsInterface)->Expect.String.toContain(
+          "let outletForUrl: string => option<outlet>",
+        )
         expect(routeDeclarationsInterface)->Expect.String.toContain(
           "let make: (~prepareDisposeTimeout: int=?) => array<RelayRouter.Types.route>",
         )
-        expect(routeDeclarationsInterface)->Expect.not->Expect.String.toContain("module Root:")
-        expect(routeDeclarationsInterface)->Expect.not->Expect.String.toContain("module Embedded:")
       },
     )
   })

--- a/packages/rescript-relay-router/test/RescriptRelayRouterCli__Parser_test.test.res
+++ b/packages/rescript-relay-router/test/RescriptRelayRouterCli__Parser_test.test.res
@@ -200,17 +200,16 @@ describe("Parsing", () => {
     )->Expect.Array.toContain(`"entrypoint" needs to be a boolean. Found string("true").`)
   })
 
-  test("reports entrypoint route names that shadow the router runtime module", _t => {
+  test("reports top-level route names that shadow the router runtime module", _t => {
     let {errors} = parseRouteStructure(`[
       {
         "name": "RelayRouter",
-        "path": "/router",
-        "entrypoint": true
+        "path": "/router"
       }
     ]`)
 
     expect(
       errors->Array.map(error => error.message),
-    )->Expect.Array.toContain(`"RelayRouter" cannot be used as an entrypoint route name because it would shadow the router runtime module in generated route declarations.`)
+    )->Expect.Array.toContain(`"RelayRouter" cannot be used as a top-level route name because it would shadow the router runtime module in generated route declarations.`)
   })
 })

--- a/packages/rescript-relay-router/test/RouteSlots.test.res
+++ b/packages/rescript-relay-router/test/RouteSlots.test.res
@@ -23,6 +23,28 @@ let renderElement = text =>
       {childRoutes}
     </section>
 
+let makeRoute = (~path, ~name, ~slots=[], ~outlet=?, ~effectiveOutlet=?, ~children=[], ()) => {
+  RelayRouter__Types.path,
+  name,
+  slots,
+  outlet,
+  effectiveOutlet,
+  loadRouteRenderer: () => Promise.resolve(),
+  preloadCode: (~environment as _, ~pathParams as _, ~queryParams as _, ~location as _) =>
+    Promise.resolve([]),
+  prepare: (
+    ~environment as _,
+    ~pathParams as _,
+    ~queryParams as _,
+    ~location as _,
+    ~intent as _,
+  ) => {
+    routeKey: name,
+    render,
+  },
+  children,
+}
+
 let renderShellWithOverlay = (~childRoutes) =>
   <section>
     <span> {React.string("shell")} </span>
@@ -159,5 +181,40 @@ describe("RelayRouter__RouteSlots", () => {
     expect(html)->Expect.String.toContain("shell")
     expect(html)->Expect.String.toContain("preferences")
     expect(html)->Expect.String.toContain("account")
+  })
+})
+
+describe("RelayRouter.Internal.outletForUrl", () => {
+  test("returns the deepest match effective outlet", _t => {
+    let routes = [
+      makeRoute(
+        ~path="/",
+        ~name="Root",
+        ~slots=["Overlay"],
+        ~children=[
+          makeRoute(
+            ~path="settings",
+            ~name="Settings",
+            ~outlet="Overlay",
+            ~effectiveOutlet="Overlay",
+            ~children=[makeRoute(~path="account", ~name="Account", ~effectiveOutlet="Overlay", ())],
+            (),
+          ),
+          makeRoute(~path="todos", ~name="Todos", ()),
+        ],
+        (),
+      ),
+    ]
+
+    let compiledRoutes = routes->RelayRouter.Internal.compileRoutes
+
+    expect(
+      RelayRouter.Internal.outletForUrl(compiledRoutes, "/settings/account?tab=profile"),
+    )->Expect.toBe(Some("Overlay"))
+    expect(RelayRouter.Internal.outletForUrl(compiledRoutes, "settings/account"))->Expect.toBe(
+      Some("Overlay"),
+    )
+    expect(RelayRouter.Internal.outletForUrl(compiledRoutes, "/todos"))->Expect.toBe(None)
+    expect(RelayRouter.Internal.outletForUrl(compiledRoutes, "/missing"))->Expect.toBe(None)
   })
 })

--- a/plans/2026-05-20-root-outlet-for-url.md
+++ b/plans/2026-05-20-root-outlet-for-url.md
@@ -1,0 +1,32 @@
+# Root Outlet Resolution
+
+## Decision
+
+Codex implemented root-scoped `RouteDeclarations.<Root>.outletForUrl(url)` helpers that return the deepest matched route's effective outlet as a generated typed variant.
+
+## Why
+
+Kandan needs to decide whether a URL belongs in a route slot without duplicating route parsing or manually walking route configs. The router already has a matcher and generated route declarations, so this belongs in generated declarations rather than app code.
+
+## Implementation
+
+- Runtime route declarations now store both direct `outlet` and inherited `effectiveOutlet`.
+- Codegen propagates a parent effective outlet to descendants unless a route declares its own outlet.
+- `RelayRouter.Internal.outletForUrl(compiledRoutes, url)` uses the existing compiled route matcher and returns the deepest match's `effectiveOutlet`.
+- `RouteDeclarations.<Root>.outletForUrl(url)` scopes matching to that root's route tree, uses a module-level precompiled route matcher, and maps the internal string outlet to the root module's `outlet` variant.
+- Root modules are now emitted for every top-level route. Only routes marked `entrypoint: true` expose `make`.
+
+## Verification
+
+Codex verified with:
+
+- `yarn rescript format`
+- `yarn build`
+- `yarn test`
+- `git diff --check`
+
+## Non-Goals
+
+- No rendering behavior changes.
+- No support for multiple simultaneous outlet branches in one URL.
+- No app-specific Kandan pane or overlay API.


### PR DESCRIPTION
## What changed

- Preserves inherited effective outlet metadata on generated route declarations.
- Adds root-scoped `RouteDeclarations.<Root>.outletForUrl(url)` helpers that match through the existing compiled router matcher.
- Adds docs, a changeset, generated example output, and runtime/codegen coverage.

## Why

Apps need to ask whether a URL belongs to a route outlet without duplicating route parsing or manually mirroring generated route priority.

## Validation

- `yarn rescript format`
- `yarn build`
- `yarn test`
- `git diff --check`
